### PR TITLE
Fix #1296 - upgrade information link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ User documentation is [here](https://opendatakit.org/use/aggregate/)
 The forum for user questions is: [The ODK Forum](https://forum.opendatakit.org/)
 
 See [CONFIGURE.md](https://github.com/opendatakit/aggregate/blob/master/CONFIGURE.md) for build information
-and [README.md](https://github.com/opendatakit/aggregate/blob/master/README.md) for upgrade information.
+and [wiki](https://github.com/opendatakit/opendatakit/wiki/Aggregate-Release-Notes) for upgrade information.
 
 The developer [wiki](https://github.com/opendatakit/opendatakit/wiki) (including release notes) and
 [issues tracker](https://github.com/opendatakit/opendatakit/issues) are located under


### PR DESCRIPTION
Updated the upgrade information link to point to the wiki page as a fix
for: https://github.com/opendatakit/opendatakit/issues/1296