### PR TITLE
Remove duplicate lists of classes used for JavaRosa serialization

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.IDataReference;
@@ -38,6 +39,7 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.PrototypeManager;
+import org.javarosa.core.util.JavaRosaCoreModule;
 import org.javarosa.model.xform.XFormsModule;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.util.XFormUtils;
@@ -63,57 +65,21 @@ public class BaseFormParserForJavaRosa {
   private static final String LEADING_QUESTION_XML_PATTERN = "^[^<]*<\\s*\\?\\s*xml.*";
   private static final Log log = LogFactory.getLog(BaseFormParserForJavaRosa.class.getName());
 
-  /**
-   * Classes needed to serialize objects. Need to put anything from JR in here.
-   */
-  public final static String[] SERIALIABLE_CLASSES = {
-    "org.javarosa.core.services.locale.ResourceFileDataSource", // JavaRosaCoreModule
-    "org.javarosa.core.services.locale.TableLocaleSource", // JavaRosaCoreModule
-    "org.javarosa.core.model.FormDef",
-    "org.javarosa.core.model.SubmissionProfile", // CoreModelModule
-    "org.javarosa.core.model.QuestionDef", // CoreModelModule
-    "org.javarosa.core.model.GroupDef", // CoreModelModule
-    "org.javarosa.core.model.instance.FormInstance", // CoreModelModule
-    "org.javarosa.core.model.data.BooleanData", // CoreModelModule
-    "org.javarosa.core.model.data.DateData", // CoreModelModule
-    "org.javarosa.core.model.data.DateTimeData", // CoreModelModule
-    "org.javarosa.core.model.data.DecimalData", // CoreModelModule
-    "org.javarosa.core.model.data.GeoPointData", // CoreModelModule
-    "org.javarosa.core.model.data.GeoShapeData", // CoreModelModule
-    "org.javarosa.core.model.data.GeoTraceData", // CoreModelModule
-    "org.javarosa.core.model.data.IntegerData", // CoreModelModule
-    "org.javarosa.core.model.data.LongData", // CoreModelModule
-    "org.javarosa.core.model.data.MultiPointerAnswerData", // CoreModelModule
-    "org.javarosa.core.model.data.PointerAnswerData", // CoreModelModule
-    "org.javarosa.core.model.data.SelectMultiData", // CoreModelModule
-    "org.javarosa.core.model.data.SelectOneData", // CoreModelModule
-    "org.javarosa.core.model.data.StringData", // CoreModelModule
-    "org.javarosa.core.model.data.TimeData", // CoreModelModule
-    "org.javarosa.core.model.data.UncastData", // CoreModelModule
-    "org.javarosa.core.model.data.helper.BasicDataPointer", // CoreModelModule
-    "org.javarosa.core.model.Action", // CoreModelModule
-    "org.javarosa.core.model.actions.SetValueAction" //CoreModelModule
-  };
-
   private static boolean isJavaRosaInitialized = false;
   /**
    * The JR implementation here does not look thread-safe or
    * like something to be invoked more than once.
    * Moving it within a critical section and a do-once guard.
    */
-  private static final void initializeJavaRosa() {
+  private static void initializeJavaRosa() {
     synchronized (log) {
-       if ( !isJavaRosaInitialized ) {
-             // need a list of classes that formdef uses
-             // unfortunately, the JR registerModule() functions do more than this.
-             // register just the classes that would have been registered by:
-             // new JavaRosaCoreModule().registerModule();
-             // new CoreModelModule().registerModule();
-             // replace with direct call to PrototypeManager
-             PrototypeManager.registerPrototypes(SERIALIABLE_CLASSES);
-             new XFormsModule().registerModule();
-             isJavaRosaInitialized = true;
-       }
+      if (!isJavaRosaInitialized) {
+        // Register prototypes for classes that FormDef uses
+        PrototypeManager.registerPrototypes(JavaRosaCoreModule.classNames);
+        PrototypeManager.registerPrototypes(CoreModelModule.classNames);
+        new XFormsModule().registerModule();
+        isJavaRosaInitialized = true;
+      }
     }
   }
 


### PR DESCRIPTION
Use classnames newly exposed from JavaRosa, rather than maintaining this list of classnames here as well as in JavaRosa (and in Collect).
Depends on https://github.com/dcbriccetti/javarosa/commit/15a825805a3f5976a908d0e8a1b65c7f8642cf96 .

@mitchellsundt, how does this look?

I can’t yet build and test Aggregate. I wonder if one of you who can could test this? 