### PR TITLE
New feature that lets a user see Audit CSV contents inside a popup in Aggregate's submissions table

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/popups/AuditCSVPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/AuditCSVPopup.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2011 University of Washington
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.client.popups;
+
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.SimplePanel;
+import org.opendatakit.aggregate.client.AggregateUI;
+import org.opendatakit.aggregate.client.SecureGWT;
+import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
+import org.opendatakit.aggregate.constants.common.UIConsts;
+
+
+public class AuditCSVPopup extends AbstractPopupBase {
+  public AuditCSVPopup(String keyString) {
+    super();
+    String[] parts = keyString.split("\\?");
+    if (parts.length != 2)
+      throw new RuntimeException("blobKey missing in keyString");
+    String blobKey = parts[1].split("=")[1];
+
+    setTitle("Audit CSV");
+    int width = Window.getClientWidth() / 2;
+    int height = Window.getClientHeight() / 2;
+
+    final FlowPanel panel = new FlowPanel();
+    panel.setStylePrimaryName(UIConsts.VERTICAL_FLOW_PANEL_STYLENAME);
+    panel.setPixelSize(width + 6, height + 30);
+    panel.add(new SimplePanel(new ClosePopupButton(this)));
+    final HTML loading = new HTML("<h1>Loading Audit CSV... Please wait</h1>");
+    panel.add(loading);
+    setWidget(panel);
+
+
+    AsyncCallback<String> callback = new AsyncCallback<String>() {
+      public void onFailure(Throwable caught) {
+        AggregateUI.getUI().reportError(caught);
+      }
+
+      public void onSuccess(String csvContents) {
+        AggregateUI.getUI().clearError();
+        panel.remove(loading);
+        panel.add(new HTML(csvContents));
+        AggregateUI.resize();
+      }
+    };
+
+    SecureGWT.getSubmissionService().getSubmissionAuditCSV(blobKey, callback);
+  }
+}

--- a/src/main/java/org/opendatakit/aggregate/client/submission/SubmissionService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/submission/SubmissionService.java
@@ -32,4 +32,5 @@ public interface SubmissionService extends RemoteService {
   
   SubmissionUISummary getRepeatSubmissions(String keyString) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
   
+  String getSubmissionAuditCSV(String keyString) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/submission/SubmissionServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/submission/SubmissionServiceAsync.java
@@ -26,4 +26,5 @@ public interface SubmissionServiceAsync {
 
   void getRepeatSubmissions(String keyString, AsyncCallback<SubmissionUISummary> callback);
 
+  void getSubmissionAuditCSV(String keyString, AsyncCallback<String> async);
 }

--- a/src/main/java/org/opendatakit/aggregate/client/table/AuditCSVPopupClickHandler.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/AuditCSVPopupClickHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2013 University of Washington
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.client.table;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import org.opendatakit.aggregate.client.AggregateUI;
+import org.opendatakit.aggregate.client.popups.AuditCSVPopup;
+
+public class AuditCSVPopupClickHandler implements ClickHandler {
+
+  private final String keyString;
+
+  public AuditCSVPopupClickHandler(String keyString) {
+    this.keyString = keyString;
+  }
+
+  @Override
+  public void onClick(ClickEvent event) {
+    AuditCSVPopup popup = new AuditCSVPopup(keyString);
+    popup.setPopupPositionAndShow(popup.getPositionCallBack());
+    AggregateUI.getUI().getTimer().restartTimer();
+  }
+}

--- a/src/main/java/org/opendatakit/aggregate/client/table/SubmissionTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/SubmissionTable.java
@@ -16,7 +16,8 @@
 
 package org.opendatakit.aggregate.client.table;
 
-import java.util.ArrayList;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.Image;
 
 import org.opendatakit.aggregate.client.submission.Column;
 import org.opendatakit.aggregate.client.submission.SubmissionUI;
@@ -26,8 +27,7 @@ import org.opendatakit.aggregate.client.widgets.RepeatViewButton;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.opendatakit.common.web.constants.BasicConsts;
 
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.Image;
+import java.util.ArrayList;
 
 public class SubmissionTable extends FlexTable {
 
@@ -74,6 +74,11 @@ public class SubmissionTable extends FlexTable {
         case BINARY:
           if (value == null) {
             setText(rowPosition, columnPosition, BasicConsts.EMPTY_STRING);
+            } else if (tableHeaders.get(valueIndex - 1).getDisplayHeader().equals("meta:audit")) {
+              Image image = new Image(value + UIConsts.PREVIEW_SET);
+              image.setStyleName(UIConsts.PREVIEW_IMAGE_STYLENAME);
+              image.addClickHandler(new AuditCSVPopupClickHandler(value));
+              setWidget(rowPosition, columnPosition, image);
           } else {
             Image image = new Image(value + UIConsts.PREVIEW_SET);
             image.setStyleName(UIConsts.PREVIEW_IMAGE_STYLENAME);

--- a/src/main/java/org/opendatakit/aggregate/client/table/SubmissionTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/SubmissionTable.java
@@ -18,7 +18,6 @@ package org.opendatakit.aggregate.client.table;
 
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.Image;
-
 import org.opendatakit.aggregate.client.submission.Column;
 import org.opendatakit.aggregate.client.submission.SubmissionUI;
 import org.opendatakit.aggregate.client.submission.SubmissionUISummary;
@@ -32,6 +31,7 @@ import java.util.ArrayList;
 public class SubmissionTable extends FlexTable {
 
   private static final String BLANK_VALUE = " ";
+  private static final String META_AUDIT_FIELD = "meta:audit";
   private ArrayList<Column> tableHeaders;
   private ArrayList<SubmissionUI> tableSubmissions;
 
@@ -41,7 +41,7 @@ public class SubmissionTable extends FlexTable {
 
     addStyleName("dataTable");
     getElement().setId("submission_table");
-    
+
     // setup header
     int headerIndex = 0;
     if (addDeleteButton) {
@@ -60,42 +60,42 @@ public class SubmissionTable extends FlexTable {
     for (SubmissionUI row : tableSubmissions) {
       int valueIndex = 0; // index matches to column headers
       int columnPosition = 0; // position matches to position in table
-   
+
       // if authorized add delete button
       if (addDeleteButton) {
         DeleteSubmissionButton delete = new DeleteSubmissionButton(row.getSubmissionKeyAsString());
         setWidget(rowPosition, columnPosition, delete);
         columnPosition++;
       }
-   
+
       // generate row
       for (final String value : row.getValues()) {
         switch (tableHeaders.get(valueIndex++).getUiDisplayType()) {
-        case BINARY:
-          if (value == null) {
-            setText(rowPosition, columnPosition, BasicConsts.EMPTY_STRING);
-            } else if (tableHeaders.get(valueIndex - 1).getDisplayHeader().equals("meta:audit")) {
+          case BINARY:
+            if (value == null) {
+              setText(rowPosition, columnPosition, BasicConsts.EMPTY_STRING);
+            } else if (tableHeaders.get(valueIndex - 1).getDisplayHeader().equals(META_AUDIT_FIELD)) {
               Image image = new Image(value + UIConsts.PREVIEW_SET);
               image.setStyleName(UIConsts.PREVIEW_IMAGE_STYLENAME);
               image.addClickHandler(new AuditCSVPopupClickHandler(value));
               setWidget(rowPosition, columnPosition, image);
-          } else {
-            Image image = new Image(value + UIConsts.PREVIEW_SET);
-            image.setStyleName(UIConsts.PREVIEW_IMAGE_STYLENAME);
-            image.addClickHandler(new BinaryPopupClickHandler(value, false));
-            setWidget(rowPosition, columnPosition, image);
-          }
-          break;
-        case REPEAT:
-          if (value == null) {
-            setText(rowPosition, columnPosition, BasicConsts.EMPTY_STRING);
-          } else {
-            RepeatViewButton repeat = new RepeatViewButton(value);
-            setWidget(rowPosition, columnPosition, repeat);
-          }
-          break;
-        default:
-          setText(rowPosition, columnPosition, value);
+            } else {
+              Image image = new Image(value + UIConsts.PREVIEW_SET);
+              image.setStyleName(UIConsts.PREVIEW_IMAGE_STYLENAME);
+              image.addClickHandler(new BinaryPopupClickHandler(value, false));
+              setWidget(rowPosition, columnPosition, image);
+            }
+            break;
+          case REPEAT:
+            if (value == null) {
+              setText(rowPosition, columnPosition, BasicConsts.EMPTY_STRING);
+            } else {
+              RepeatViewButton repeat = new RepeatViewButton(value);
+              setWidget(rowPosition, columnPosition, repeat);
+            }
+            break;
+          default:
+            setText(rowPosition, columnPosition, value);
         }
         columnPosition++;
       }
@@ -114,5 +114,5 @@ public class SubmissionTable extends FlexTable {
   public ArrayList<SubmissionUI> getSubmissions() {
     return tableSubmissions;
   }
-    
+
 }


### PR DESCRIPTION
This PR solves #102 

It covers just a basic feature to enable users to see Audit CSV contents inside a simple popup. 

Some UI improvements that could be addressed:
 - New button image (currently using preview button image)
 - Some styling or HTML structuring to the Audit CSV data (maybe formatting it into a table)

Some code improvements that could also be addressed:
 - Reduce duplication of code in `SubmissionServiceImpl` and `BinaryDataServlet`
