### PR TITLE
Replace msundt with administrator or example

### DIFF
--- a/bitrock-installer/conf_variants/common/security.properties
+++ b/bitrock-installer/conf_variants/common/security.properties
@@ -41,7 +41,7 @@ security.server.superUser=
 
 # Define a superUserUsername to insert an ODK Aggregate username that can
 # access the server.  The initial password for this username is 'aggregate'
-security.server.superUserUsername=msundt
+security.server.superUserUsername=administrator
 
 # realm definition
 # realmString -- what should be sent to users when BasicAuth or DigestAuth is done

--- a/bitrock-installer/files/legacyremoval/WEB-INF/appengine-web.xml
+++ b/bitrock-installer/files/legacyremoval/WEB-INF/appengine-web.xml
@@ -1,5 +1,5 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-	<application>msundt-odk-aggregate-hrd</application>
+	<application>example-odk-aggregate-hrd</application>
 	<version>1</version>
     <threadsafe>true</threadsafe>
 </appengine-web-app>

--- a/functionalTest/resources/Integration.properties
+++ b/functionalTest/resources/Integration.properties
@@ -1,7 +1,7 @@
-test.server.hostname=192.168.1.174
+test.server.hostname=example.org
 test.server.port=8080
 test.server.baseUrl=/
-test.server.username=msundt
+test.server.username=administrator
 test.server.password=aggregate
 test.forms.dir=../src/test/testfiles/forms
 test.submissions.dir=../src/test/testfiles/submissions

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -41,7 +41,7 @@ security.server.superUser=
 
 # Define a superUserUsername to insert an ODK Aggregate username that can
 # access the server.  The initial password for this username is 'aggregate'
-security.server.superUserUsername=msundt
+security.server.superUserUsername=administrator
 
 # realm definition
 # realmString -- what should be sent to users when BasicAuth or DigestAuth is done


### PR DESCRIPTION
Closes #136.

In places where there are usernames, I replaced `msundt` with `administrator`. In places without usernames, I used `example` and `example.org`.

This is a find/replace PR without any verification, but the only risk I can think of is that some platforms, somehow, may not allow `administrator`. That seems unlikely because I have used `administrator` for installs on GAE and Tomcat.