### PR TITLE
Solve (partially) dupes/missing rows/wrong sequences in repeat tables

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/submission/type/RepeatSubmissionType.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/RepeatSubmissionType.java
@@ -67,7 +67,8 @@ public class RepeatSubmissionType implements SubmissionRepeat {
    * List of submission sets that are a part of this submission set Ordered by
    * OrdinalNumber...
    */
-  private List<SubmissionSet> submissionSets = new ArrayList<SubmissionSet>();
+  private List<SubmissionSet> submissionSets = new ArrayList<>();
+  private Map<Long, SubmissionSet> submissionSetIndex = new HashMap<>();
 
   public RepeatSubmissionType(SubmissionSet enclosingSet, FormElementModel repeatGroup,
                               String uriAssociatedRow, IForm form) {
@@ -93,6 +94,7 @@ public class RepeatSubmissionType implements SubmissionRepeat {
 
   public void addSubmissionSet(SubmissionSet submissionSet) {
     submissionSets.add(submissionSet);
+    submissionSetIndex.put(submissionSet.getOrdinalNumber(), submissionSet);
   }
 
   public List<SubmissionSet> getSubmissionSets() {
@@ -129,8 +131,13 @@ public class RepeatSubmissionType implements SubmissionRepeat {
 
     List<CommonFieldsBase> repeatRows = getRepeatRows(cc, submission);
 
-    for (List<DynamicBase> groupOfRepeatRows : groupPerOrdinalNumber(submission, repeatRows))
-      submissionSets.add(new SubmissionSet(enclosingSet, chooseOneFrom(groupOfRepeatRows), repeatGroup, form, cc));
+    for (List<DynamicBase> groupOfRepeatRows : groupPerOrdinalNumber(submission, repeatRows)) {
+      DynamicBase row = chooseOneFrom(groupOfRepeatRows);
+      SubmissionSet submissionSet = new SubmissionSet(enclosingSet, row, repeatGroup, form, cc);
+      submissionSets.add(submissionSet);
+      submissionSetIndex.put(row.getOrdinalNumber(), submissionSet);
+    }
+
   }
 
   private Collection<List<DynamicBase>> groupPerOrdinalNumber(DynamicBase submission, List<CommonFieldsBase> repeatRows) {
@@ -268,8 +275,7 @@ public class RepeatSubmissionType implements SubmissionRepeat {
 
     Long ordinalNumber = p.getOrdinalNumber();
     if (ordinalNumber != null) {
-      return submissionSets.get(ordinalNumber.intValue() - 1).resolveSubmissionKeyBeginningAt(i,
-          parts);
+      return submissionSetIndex.get(ordinalNumber).resolveSubmissionKeyBeginningAt(i, parts);
     }
 
     String auri = p.getAuri();

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -28,7 +28,7 @@ security.server.channelType=REQUIRES_INSECURE_CHANNEL
 # external services.
 #
 # This is configured during install.  If blank, discovers an IP address
-security.server.hostname=192.168.1.161
+security.server.hostname=localhost
 security.server.port=8080
 security.server.securePort=8443
 

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -28,7 +28,7 @@ security.server.channelType=REQUIRES_INSECURE_CHANNEL
 # external services.
 #
 # This is configured during install.  If blank, discovers an IP address
-security.server.hostname=localhost
+security.server.hostname=192.168.1.161
 security.server.port=8080
 security.server.securePort=8443
 


### PR DESCRIPTION
Closes #134

This PR solves a problem I introduced in a wrong rebase in PR #141 

Warning the user about missing/dupes in repeat tables would be handled in #135 

To test this PR, you can use these forms: 

- Normal repeat [Untitled Form.xml.tar.gz](https://github.com/opendatakit/aggregate/files/1476411/Untitled.Form.xml.tar.gz)
- Nested repeat [nested-repeats.xml.tar.gz](https://github.com/opendatakit/aggregate/files/1499968/nested-repeats.xml.tar.gz)

Just send a submission and alter the database to produce missing rows and duped rows. This example has a dupe row for `_ORDINAL_NUMBER` 1 and has no row for `_ORDINAL_NUMBER` 2.

_URI | _CREATOR_URI_USER | _CREATION_DATE | _LAST_UPDATE_URI_USER | _LAST_UPDATE_DATE | _PARENT_AURI | _ORDINAL_NUMBER | _TOP_LEVEL_AURI | SOME_TEXT
-- | -- | -- | -- | -- | -- | -- | -- | --
uuid:46666a40-dfbf-4255-bcd4-e34b33325000 | anonymousUser | 2017-11-13 22:16:31.859000 | NULL | 2017-11-15 22:16:31.859000 | uuid:f99e6bd0-e07a-4b1b-b121-a34b8c852319 | 1 | uuid:f99e6bd0-e07a-4b1b-b121-a34b8c852319 | 1
uuid:46666a40-dfbf-4255-bcd4-e34b33325001 | anonymousUser | 2017-11-14 22:16:31.859000 | NULL | 2017-11-15 22:16:31.859000 | uuid:f99e6bd0-e07a-4b1b-b121-a34b8c852319 | 1 | uuid:f99e6bd0-e07a-4b1b-b121-a34b8c852319 | 2
uuid:46666a40-dfbf-4255-bcd4-e34b33325002 | anonymousUser | 2017-11-15 22:16:31.859000 | NULL | 2017-11-15 22:16:31.859000 | uuid:f99e6bd0-e07a-4b1b-b121-a34b8c852319 | 3 | uuid:f99e6bd0-e07a-4b1b-b121-a34b8c852319 | 3

With this data, you should be able to see and export a group with rows for the text '2' and '3':

![demo_repeat_group](https://user-images.githubusercontent.com/205913/32861463-11030e20-ca55-11e7-9402-ee4a681c1437.png)
