### PR TITLE
Prevent refresh hell on identified cases of data corruption

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/constants/ErrorConsts.java
+++ b/src/main/java/org/opendatakit/aggregate/constants/ErrorConsts.java
@@ -26,6 +26,7 @@ package org.opendatakit.aggregate.constants;
  */
 public final class ErrorConsts {
 
+  public static final String POSSIBLE_CORRUPTION = "Encountered an unknown problem while reading the database. This often is a sign of database corruption. Please get the server logs and file an issue at https://github.com/opendatakit/aggregate/issues";
   /**
    * Error message if the form with FORM ID is not found
    */

--- a/src/main/java/org/opendatakit/aggregate/form/Form.java
+++ b/src/main/java/org/opendatakit/aggregate/form/Form.java
@@ -713,5 +713,8 @@ class Form implements IForm {
     return infoRow.getUri();
   }
 
-
+  @Override
+  public boolean isValid() {
+    return filesetRow.hasField(FormInfoFilesetTable.IS_DOWNLOAD_ALLOWED);
+  }
 }

--- a/src/main/java/org/opendatakit/aggregate/form/FormDefinition.java
+++ b/src/main/java/org/opendatakit/aggregate/form/FormDefinition.java
@@ -111,9 +111,10 @@ public class FormDefinition {
 		return null;
 	}
 
-	private static final SubmissionAssociationTable getSubmissionAssociation(String formId, boolean canBeIncomplete, CallingContext cc ) {
-		SubmissionAssociationTable sa = null;
-		{
+	private static final SubmissionAssociationTable getSubmissionAssociation(String formId, boolean canBeIncomplete, CallingContext cc) {
+		try {
+			SubmissionAssociationTable sa = null;
+			{
 		    List<SubmissionAssociationTable> saList = SubmissionAssociationTable.findSubmissionAssociationsForXForm(formId, cc);
 		    if ( saList.isEmpty() ) {
 		    	// may be in the process of being defined, or in a partially defined state.
@@ -135,9 +136,13 @@ public class FormDefinition {
 		    		sa = st;
 		    	}
 		    }
-		}
+			}
 	    return sa;
-	}
+		} catch (Throwable t) {
+      logger.error("Returning null SubmissionAssociationTable", t);
+      return null;
+    }
+  }
 
 	/**
 	 * Traverse the form data model and assertRelation() on all the backing objects.

--- a/src/main/java/org/opendatakit/aggregate/form/FormFactory.java
+++ b/src/main/java/org/opendatakit/aggregate/form/FormFactory.java
@@ -16,15 +16,6 @@
 
 package org.opendatakit.aggregate.form;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opendatakit.aggregate.exception.ODKConversionException;
@@ -41,6 +32,8 @@ import org.opendatakit.common.persistence.exception.ODKEntityNotFoundException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
 import org.opendatakit.common.security.User;
 import org.opendatakit.common.web.CallingContext;
+
+import java.util.*;
 
 /**
  * Factory class for managing Form objects.
@@ -121,6 +114,12 @@ public class FormFactory {
           cache.add(f);
         }
       }
+
+      for (IForm form : cache)
+        if (!form.isValid()) {
+          logger.error("Possible corruption: Form with URI " + form.getUri() + " is not valid");
+          cache.remove(form);
+        }
 
       // sort by form title then by form id
       Collections.sort(forms, new Comparator<IForm>() {

--- a/src/main/java/org/opendatakit/aggregate/form/IForm.java
+++ b/src/main/java/org/opendatakit/aggregate/form/IForm.java
@@ -265,4 +265,6 @@ public interface IForm {
   public boolean setXFormMediaFile(MultiPartFormItem item, boolean overwriteOK, CallingContext cc) throws ODKDatastoreException;
   
   public String getUri();
+
+  boolean isValid();
 }

--- a/src/main/java/org/opendatakit/aggregate/server/FormServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/FormServiceImpl.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -62,6 +64,7 @@ import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
 public class FormServiceImpl extends RemoteServiceServlet implements
     org.opendatakit.aggregate.client.form.FormService {
+  private static final Log logger = LogFactory.getLog(FormServiceImpl.class);
 
   /**
    * Serial number for serialization
@@ -122,11 +125,14 @@ public class FormServiceImpl extends RemoteServiceServlet implements
       return formSummaries;
 
     } catch (ODKOverQuotaException e) {
-      e.printStackTrace();
+      logger.error(e);
       throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
-      e.printStackTrace();
+      logger.error(e);
       throw new DatastoreFailureException();
+    } catch (Throwable t) {
+      logger.error("Possible corruption", t);
+      throw new RequestFailureException(ErrorConsts.POSSIBLE_CORRUPTION);
     }
   }
 

--- a/src/main/java/org/opendatakit/common/persistence/CommonFieldsBase.java
+++ b/src/main/java/org/opendatakit/common/persistence/CommonFieldsBase.java
@@ -165,6 +165,17 @@ public abstract class CommonFieldsBase {
     return Collections.unmodifiableList(fieldList);
   }
 
+  public final boolean hasField(DataField f) {
+    if (f == null) {
+      throw new IllegalArgumentException("Field value is null!");
+    }
+    if (!fieldList.contains(f)) {
+      throw new IllegalArgumentException("Attempting to get a field " + f.getName()
+          + " not belonging to " + schemaName + "." + tableName);
+    }
+    return fieldValueMap.containsKey(f);
+  }
+
   public final String getStringField(DataField f) {
     if (f == null) {
       throw new IllegalArgumentException("Field value is null!");


### PR DESCRIPTION
Add new controls to prevent constant refresh of the UI due to unhandled exceptions server-side
Add log traces that give more information about these unhandled exceptions
Add github issues link in POSSIBLE_CORRUPTION error text

Closes #114

Comes from #127 