### PR TITLE
No gretty logs in $HOME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ war
 .gradle
 installer/appEngineSDK.zip
 gradle.properties
+logs

--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ war {
 gretty {
   contextPath = '/'
   host = 'localhost'
+  logDir = 'logs'
 }
 
 task gaeDownloadSDK() {


### PR DESCRIPTION
Closes #169 

#### What has been done to verify that this works as intended?
Confirmed that logs are written to the project folder and not the #HOME folder. Also confirmed that logs folder is not committed.

#### Why is this the best possible solution? Were any other approaches considered?
We could have used  http://akhikhl.github.io/gretty-doc/Logging.html to have a configure file, but this seems like the correct default behavior. Others can override if necessary.

#### Are there any risks to merging this code? If so, what are they?
I'm hoping that this doesn't override some logs in the application itself. I did not verify, but I don't think so though.
