### PR TITLE
Enable Git LFS and fix broken build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
       - run:
           name: Configure build
           command: cp gradle.properties.example gradle.properties
-      - run: ./gradlew check -x test war
+      # breaking up the commands prevents out of memory errors on CircleCI
+      - run: ./gradlew check -x test
+      - run: ./gradlew war -x test
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,15 @@ jobs:
       - image: circleci/openjdk:latest
     steps:
       - checkout
+      - run:
+          name: Install checkout requirements
+          command: |
+            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+            sudo apt-get install git-lfs
+            git lfs install
+      - run:
+          name: Checkout binaries
+          command: git lfs pull
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}
       - run:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ ODK Aggregate can be deployed on Google's App Engine, enabling users to quickly 
 
 1. Fork the Aggregate project ([why and how to fork](https://help.github.com/articles/fork-a-repo/))
 
+1. Install [Git LFS](https://git-lfs.github.com/)
+
 1. Clone your fork of the project locally. At the command line:
 
         git clone https://github.com/YOUR-GITHUB-USERNAME/aggregate
@@ -164,6 +166,8 @@ If you're ready to contribute code, see [the contribution guide](CONTRIBUTING.md
 The best way to help us test is to build from source! We are currently focusing on stabilizing the build process.
 
 ## Troubleshooting
+
+* We enabled Git LFS on the Aggregate codebase and reduced the repo size from 700 MB to 34 MB. No code was changed, but if you cloned before December 11th, 2017, you'll need to reclone the project.
 
 * If you get an **Invalid Gradle JDK configuration found** error importing the code, you might not have set the `JAVA_HOME` environment variable. Try [these solutions](https://stackoverflow.com/questions/32654016/).
 


### PR DESCRIPTION
Closes #128

#### What has been done to verify that this works as intended?
I tried the build on my CircleCI account and successfully got a build. 

#### Why is this the best possible solution? Were any other approaches considered?
We've used the Git LFS install technique on other ODK repos. The splitting up of the commands is silly, but I found it more reliable than the many attempts at setting correct values for `_JAVA_OPTS` and `GRADLE_OPTS`

#### Are there any risks to merging this code? If so, what are they?
Nope. 