### PR TITLE
Enable testing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,17 @@ jobs:
     working_directory: ~/src
     docker:
       - image: circleci/openjdk:latest
+      - image: circleci/postgres:9.6
+        environment:
+        - POSTGRES_USER=circleci
+        - POSTGRES_DB=circleci
     steps:
       - checkout
       - run:
-          name: Install checkout requirements
+          name: Install requirements
           command: |
             curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-            sudo apt-get install git-lfs
+            sudo apt-get install postgresql-client git-lfs
             git lfs install
       - run:
           name: Checkout binaries
@@ -18,11 +22,14 @@ jobs:
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}
       - run:
+          name: Setup database
+          command: psql --host localhost --file db/test/postgresql/init.sql
+      - run:
           name: Configure build
           command: cp gradle.properties.example gradle.properties
       # breaking up the commands prevents out of memory errors on CircleCI
-      - run: ./gradlew check -x test
-      - run: ./gradlew war -x test
+      - run: ./gradlew check
+      - run: ./gradlew war
       - save_cache:
           paths:
             - ~/.gradle
@@ -34,3 +41,5 @@ jobs:
       - store_artifacts:
           path: build/libs
           destination: libs
+      - store_test_results:
+          path: build/test-results

--- a/db/test/postgresql/init.sql
+++ b/db/test/postgresql/init.sql
@@ -1,0 +1,6 @@
+CREATE USER "odk_unit" WITH UNENCRYPTED PASSWORD 'test';
+CREATE DATABASE odk_db WITH OWNER odk_unit;
+GRANT ALL PRIVILEGES ON DATABASE odk_db TO odk_unit;
+\connect odk_db;
+CREATE SCHEMA odk_db;
+GRANT ALL PRIVILEGES ON SCHEMA odk_db TO odk_unit;


### PR DESCRIPTION
Closes #188 

#### What has been done to verify that this works as intended?
I've run this on my branch and the tests run, but one test (org.opendatakit.common.persistence.QueryResultTest) fails, so the build fails. 

#### Why is this the best possible solution? Were any other approaches considered?
I've used default variables (e.g., circleci) that are the default so there is less "code" in the config. I used full switches for readability. The file location for the init.sql was done to match #181. Maybe it should be at root level?

#### Are there any risks to merging this code? If so, what are they?
Yes, this breaks the build. And because the build is broken, I'm cannot guarantee `.gradlew war` will actually produce a war. I bet it will though. Another risk is that I've grouped the gradle commands and we may run into memory problems. A final risk is that the test output is enormous and it makes loading the log in CircleCI annoying. Maybe we can silence that?

#### Remaining
- [x] Fix for QueryResultTest. Can you help here, @ggalmazor 
- [x] Confirm we get a war
- [x] Confirm we get a test artifacts/reports
- [x] Agree on a location for init.sql and update .gitignore
