### PR TITLE
Update the GAE Updater application's JAR

### DIFF
--- a/installer/gae.zip
+++ b/installer/gae.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abb0f5c1b2ebf1377ddde071f67f8491a2ed44a1d883acb55d7158ebd98e8a6e
-size 1434856
+oid sha256:e2c28bbc689c4b888e4780e4ea8b5ebe975f2829b9bfdcd8041e4594c0238e05
+size 1396896


### PR DESCRIPTION
Closes #113

This PR updates the GAE Updater application's JAR file that will get embedded inside the Aggregate installer. The new version will run on Java8 and Java9 (since it's generated with the changes from [the corresponding PR on aggregate-components project](https://github.com/opendatakit/aggregate-components/pull/2)

#### What has been done to verify that this works as intended?
Generated an installer and manually tested that

1. The installer can launch automatically the updater app
2. The updater app runs on Java8 and Java9 (tested by running it manually from the installation dir)

#### Why is this the best possible solution? Were any other approaches considered?
N/A 

#### Are there any risks to merging this code? If so, what are they?
None

#### Do we need any specific form for testing your changes? If so, please attach one.
No