### PR TITLE
Improve logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,16 @@ def versions = [
     mockito       : '2.+'
 ]
 
+configurations.all {
+  exclude group: 'commons-logging', module: 'commons-logging'
+}
+
 dependencies {
+  compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.25' // JCL over SLF4J
+  compile group: 'org.slf4j', name: 'log4j-over-slf4j', version: '1.7.25'
+  compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
+
   compile group: 'org.opendatakit', name: 'odk-tomcatutil', version: versions.odk.tomcatUtil
   compile group: 'org.springframework', name: 'spring-aop', version: versions.spring
   compile group: 'org.springframework', name: 'spring-aspects', version: versions.spring

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip
+#Tue Mar 06 20:30:40 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip

--- a/src/main/java/org/opendatakit/aggregate/datamodel/FormDataModel.java
+++ b/src/main/java/org/opendatakit/aggregate/datamodel/FormDataModel.java
@@ -18,8 +18,8 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.DataField.IndexType;
@@ -76,7 +76,7 @@ import org.opendatakit.common.web.constants.BasicConsts;
  */
 public final class FormDataModel extends CommonFieldsBase {
 
-  private static final Log logger = LogFactory.getLog(FormDataModel.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(FormDataModel.class.getName());
 
   public static final Long MAX_ELEMENT_NAME_LENGTH = PersistConsts.GUARANTEED_SEARCHABLE_LEN;
 

--- a/src/main/java/org/opendatakit/aggregate/externalservice/FormServiceCursor.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/FormServiceCursor.java
@@ -18,8 +18,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.TaskLockType;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
 import org.opendatakit.aggregate.constants.common.ExternalServiceType;
@@ -327,7 +327,7 @@ public final class FormServiceCursor extends CommonFieldsBase {
       e1.printStackTrace();
     } finally {
       if (!deleted) {
-        Log logger =LogFactory.getLog(FormServiceCursor.class);
+        Logger logger =LoggerFactory.getLogger(FormServiceCursor.class);
         logger.error("Unable to delete FormServiceCursor: " + service.getFormServiceCursor().getUri());
       }
     }

--- a/src/main/java/org/opendatakit/aggregate/externalservice/FusionTable.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/FusionTable.java
@@ -27,8 +27,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.constants.HtmlUtil;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
@@ -77,7 +77,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class FusionTable extends GoogleOauth2ExternalService implements ExternalService {
   private static final int MAX_INSERT_STRING_LEN = 30000;
 
-  private static final Log logger = LogFactory.getLog(FusionTable.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(FusionTable.class.getName());
 
   private static ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/org/opendatakit/aggregate/externalservice/FusionTable.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/FusionTable.java
@@ -110,7 +110,7 @@ public class FusionTable extends GoogleOauth2ExternalService implements External
   private FusionTable(FusionTable2ParameterTable entity, FormServiceCursor formServiceCursor,
       IForm form, CallingContext cc) throws ODKExternalServiceException {
     super(FUSION_TABLE_OAUTH2_SCOPE, form, formServiceCursor, new FusionTableElementFormatter(
-        cc.getServerURL()), new FusionTableHeaderFormatter(), logger, cc);
+        cc.getServerURL()), new FusionTableHeaderFormatter(), cc);
     this.objectEntity = entity;
   }
 

--- a/src/main/java/org/opendatakit/aggregate/externalservice/GoogleOauth2ExternalService.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/GoogleOauth2ExternalService.java
@@ -63,6 +63,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.Permission;
+import org.slf4j.LoggerFactory;
 
 /**
  * Refactoring and base implementation using the new gdata APIs for accessing
@@ -72,6 +73,7 @@ import com.google.api.services.drive.model.Permission;
  *
  */
 public abstract class GoogleOauth2ExternalService extends AbstractExternalService {
+  private static final Logger oauth2logger = LoggerFactory.getLogger(GoogleOauth2ExternalService.class);
 
   private static final String NO_EMAIL_SPECIFIED_ERROR = "No email specified to add file permission to";
   private static final String NO_PERM_RETURNED = "GOT No permssion returned in the response";
@@ -81,17 +83,13 @@ public abstract class GoogleOauth2ExternalService extends AbstractExternalServic
   protected GoogleCredential credential;
   protected HttpTransport httpTransport;
 
-  protected final Logger oauth2logger;
-
   protected HttpRequestFactory requestFactory;
 
   protected GoogleOauth2ExternalService(String credentialScope, IForm form,
       FormServiceCursor formServiceCursor, ElementFormatter formatter,
-      HeaderFormatter headerFormatter, Logger logger, CallingContext cc)
+      HeaderFormatter headerFormatter, CallingContext cc)
       throws ODKExternalServiceCredentialsException, ODKExternalServiceException {
     super(form, formServiceCursor, formatter, headerFormatter, cc);
-
-    this.oauth2logger = logger;
 
     try {
       this.credential = getCredential(credentialScope, cc);
@@ -117,7 +115,7 @@ public abstract class GoogleOauth2ExternalService extends AbstractExternalServic
           User user = cc.getCurrentUser();
           ds.putEntity(fsc, user);
         } catch (Exception e1) {
-          oauth2logger.error("Unable to persist bad credentials status" + e1.toString());
+          oauth2logger.error("Unable to persist bad credentials status", e1);
           throw new ODKExternalServiceException("unable to persist bad credentials status", e1);
         }
       }
@@ -165,7 +163,6 @@ public abstract class GoogleOauth2ExternalService extends AbstractExternalServic
       credential.refreshToken();
       return credential;
     } catch (Exception e) {
-      e.printStackTrace();
       throw new ODKExternalServiceCredentialsException(e);
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/externalservice/GoogleOauth2ExternalService.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/GoogleOauth2ExternalService.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
+import org.slf4j.Logger;
 import org.apache.http.NameValuePair;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.common.OperationalStatus;
@@ -81,13 +81,13 @@ public abstract class GoogleOauth2ExternalService extends AbstractExternalServic
   protected GoogleCredential credential;
   protected HttpTransport httpTransport;
 
-  protected final Log oauth2logger;
+  protected final Logger oauth2logger;
 
   protected HttpRequestFactory requestFactory;
 
   protected GoogleOauth2ExternalService(String credentialScope, IForm form,
       FormServiceCursor formServiceCursor, ElementFormatter formatter,
-      HeaderFormatter headerFormatter, Log logger, CallingContext cc)
+      HeaderFormatter headerFormatter, Logger logger, CallingContext cc)
       throws ODKExternalServiceCredentialsException, ODKExternalServiceException {
     super(form, formServiceCursor, formatter, headerFormatter, cc);
 

--- a/src/main/java/org/opendatakit/aggregate/externalservice/GoogleSpreadsheet.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/GoogleSpreadsheet.java
@@ -27,8 +27,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.constants.HtmlUtil;
@@ -107,7 +107,7 @@ import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
  * 
  */
 public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements ExternalService {
-  private static final Log logger = LogFactory.getLog(GoogleSpreadsheet.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(GoogleSpreadsheet.class.getName());
 
   private static final String GOOGLE_DRIVE_FILES_API = "https://www.googleapis.com/drive/v2/files";
 

--- a/src/main/java/org/opendatakit/aggregate/externalservice/GoogleSpreadsheet.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/GoogleSpreadsheet.java
@@ -101,10 +101,10 @@ import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
 
 /**
- * 
+ *
  * @author wbrunette@gmail.com
  * @author mitchellsundt@gmail.com
- * 
+ *
  */
 public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements ExternalService {
   private static final Logger logger = LoggerFactory.getLogger(GoogleSpreadsheet.class.getName());
@@ -133,21 +133,21 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
 
   /**
    * Common base constructor that initializes final values.
-   * 
+   *
    * @param form
    * @param fpObject
    * @param cc
    * @throws ODKExternalServiceException
-   * @throws IOException 
-   * @throws GeneralSecurityException 
+   * @throws IOException
+   * @throws GeneralSecurityException
    */
 
   private GoogleSpreadsheet(IForm form, GoogleSpreadsheet2ParameterTable gsObject,
       FormServiceCursor formServiceCursor, CallingContext cc) throws ODKExternalServiceException {
     super(GOOGLE_SPREADSHEET_OAUTH2_SCOPE, form, formServiceCursor, new LinkElementFormatter(
         cc.getServerURL(), FormMultipleValueServlet.ADDR, true, true, true, true),
-        new GoogleSpreadsheetHeaderFormatter(true, true, true), logger, cc);
-    
+        new GoogleSpreadsheetHeaderFormatter(true, true, true), cc);
+
     try {
       HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
 
@@ -155,10 +155,8 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
           .setApplicationName(ServletConsts.APPLICATION_NAME)
           .build();
     } catch (GeneralSecurityException e) {
-      e.printStackTrace();
       throw new ODKExternalServiceCredentialsException(e);
     } catch (IOException e) {
-      e.printStackTrace();
       throw new ODKExternalServiceException(e);
     }
 
@@ -194,7 +192,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     objectEntity.setSpreadsheetName(name);
     persist(cc);
   }
-  
+
   protected String executeDriveStmt(String spreadsheetTitle, String spreadsheetDescription,
       CallingContext cc) throws
       IOException, ODKExternalServiceException, GeneralSecurityException {
@@ -203,7 +201,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     requestBody.put("title", spreadsheetTitle);
     requestBody.put("description", spreadsheetDescription);
     requestBody.put("mimeType", "application/vnd.google-apps.spreadsheet");
-    
+
     GenericUrl url = new GenericUrl(GOOGLE_DRIVE_FILES_API);
 
     String statement = mapper.writeValueAsString(requestBody);
@@ -238,21 +236,19 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
       String spreadKey = null;
       try {
         String response = executeDriveStmt(spreadsheetName, spreadsheetDescription, cc);
-        
+
         // convert response from json to Java
         TypeReference<HashMap<Object,Object>> ref = new TypeReference<HashMap<Object,Object>>() {};
         HashMap<Object,Object> map = mapper.readValue(response, ref);
 
         // get document ID (spreadsheet 'key')
         spreadKey = (String) map.get("id");
-        
+
       } catch (IOException e) {
-        e.printStackTrace();
         throw new ODKExternalServiceException(e);
       } catch (GeneralSecurityException e) {
-        e.printStackTrace();
         throw new ODKExternalServiceCredentialsException(e);
-      }   
+      }
 
       objectEntity.setSpreadsheetKey(spreadKey);
       objectEntity.setReady(false);
@@ -278,7 +274,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
         ccDaemon.setAsDaemon(true);
         ws.createWorksheetTask(form, m, 1L, ccDaemon);
       } catch (ODKFormNotFoundException e) {
-        e.printStackTrace();
+        logger.error("Google spreadsheet error", e);
       }
     } else {
       // upload data to external service
@@ -315,15 +311,15 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
 
     // TODO: throw meaningful credentials-failure exception
     // TODO: throw meaningful credentials-failure exception
-    
-    
+
+
     List<Integer> sheetIds = new ArrayList<Integer>();
 
     // delete pre-existing worksheets and create the new sheets.
     // we first create the new sheets so that we are able to delete all of the old ones
     // (the spreadsheet is initially created with one worksheet which cannot be deleted).
-    
-    {    
+
+    {
       List<Request> requests = new ArrayList<Request>();
       Spreadsheet entry = spreadsheetService.spreadsheets().get(objectEntity.getSpreadsheetKey()).execute();
       List<Sheet> preExistingWorksheets = entry.getSheets();
@@ -336,32 +332,32 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
         // set the sheet properties
         {
           SheetProperties sheetProperties = new SheetProperties();
-          
+
           sheetProperties.setTitle(form.getFormId());
           GridProperties gridProperties = new GridProperties();
           gridProperties.setRowCount(2);
           gridProperties.setColumnCount(headers.size());
           sheetProperties.setGridProperties(gridProperties);
-          
+
           AddSheetRequest asr = new AddSheetRequest();
           asr.setProperties(sheetProperties);
           requests.add(new Request().setAddSheet(asr));
         }
-    
+
         // create worksheets for the repeat groups
         for (FormElementModel repeatGroupElement : form.getRepeatGroupsInModel()) {
           headers = headerFormatter.generateHeaders(form, repeatGroupElement, null);
-          
+
           // set the sheet properties
           {
             SheetProperties sheetProperties = new SheetProperties();
-            
+
             sheetProperties.setTitle(repeatGroupElement.getElementName());
             GridProperties gridProperties = new GridProperties();
             gridProperties.setRowCount(2);
             gridProperties.setColumnCount(headers.size());
             sheetProperties.setGridProperties(gridProperties);
-            
+
             AddSheetRequest asr = new AddSheetRequest();
             asr.setProperties(sheetProperties);
             requests.add(new Request().setAddSheet(asr));
@@ -381,24 +377,24 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
         BatchUpdateSpreadsheetRequest req = new BatchUpdateSpreadsheetRequest();
         req.setRequests(requests);
         req.setIncludeSpreadsheetInResponse(false);
-        BatchUpdateSpreadsheetResponse rsp = 
+        BatchUpdateSpreadsheetResponse rsp =
             spreadsheetService.spreadsheets().batchUpdate(objectEntity.getSpreadsheetKey(), req).execute();
         List<Response> responses = rsp.getReplies();
-        
+
         // And now stitch everything back together
         if ( responses.size() != 1 + form.getRepeatGroupsInModel().size() + preExistingWorksheets.size() ) {
           throw new IllegalStateException("Mismatch in number of responses for number of requests in batch");
         }
         AddSheetResponse asrsp = responses.get(0).getAddSheet();
-    
+
         Integer sheetId = asrsp.getProperties().getSheetId();
         sheetIds.add(sheetId);
         objectEntity.setTopLevelWorksheetId(sheetId.toString());
-    
+
         // get relation prototype for creating repeat parameter table entries
         GoogleSpreadsheet2RepeatParameterTable repeatPrototype = GoogleSpreadsheet2RepeatParameterTable
             .assertRelation(cc);
-    
+
         // create repeat worksheets
         Datastore ds = cc.getDatastore();
         User user = cc.getCurrentUser();
@@ -420,16 +416,16 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
         }
       }
     }
-    
+
     List<Request> requests = new ArrayList<Request>();
     // Write the header cells in these sheets. 
-    
+
     // create top level worksheet
     List<String> headers = headerFormatter.generateHeaders(form, form.getTopLevelGroupElement(),
         null);
-    UpdateCellsRequest topLevelWorksheet = writeColumnHeadingsCells( 
+    UpdateCellsRequest topLevelWorksheet = writeColumnHeadingsCells(
         form.getFormId(), headers, sheetIds.get(0));
-    
+
     requests.add(new Request().setUpdateCells(topLevelWorksheet));
 
     // create repeat worksheets
@@ -443,15 +439,15 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
 
       requests.add(new Request().setUpdateCells(repeatWorksheet));
     }
-    
+
     if ( !requests.isEmpty() ) {
       BatchUpdateSpreadsheetRequest req = new BatchUpdateSpreadsheetRequest();
       req.setRequests(requests);
       req.setIncludeSpreadsheetInResponse(false);
-      BatchUpdateSpreadsheetResponse rsp = 
+      BatchUpdateSpreadsheetResponse rsp =
           spreadsheetService.spreadsheets().batchUpdate(objectEntity.getSpreadsheetKey(), req).execute();
     }
-    
+
     persist(cc);
 
     // transfer ownership before marking service as prepared...
@@ -471,17 +467,17 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     // build the update request.
     UpdateCellsRequest req = new UpdateCellsRequest();
     GridRange gridRange = new GridRange();
-    
+
     gridRange.setSheetId(sheetId);
     gridRange.setStartColumnIndex(0);
     gridRange.setEndColumnIndex(headers.size());
     gridRange.setStartRowIndex(0);
     gridRange.setEndRowIndex(1);
-    
+
     req.setRange(gridRange);
-    
+
     req.setFields("*");
-    
+
     List<CellData> cells = new ArrayList<CellData>();
     int index = 0;
     for ( index = 0 ; index < headers.size(); ++index) {
@@ -492,12 +488,12 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
       cellData.setUserEnteredValue(ev);
       cells.add(cellData);
     }
-    
+
     RowData rowData = new RowData();
     rowData.setValues(cells);
     List<RowData> rows = new ArrayList<RowData>();
     rows.add(rowData);
-    
+
     req.setRows(rows);
 
     return req;
@@ -509,9 +505,9 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     List<ElementType> headerTypes;
     Map<Integer,Integer> fieldMap = new HashMap<Integer,Integer>();
   }
-  
+
   private Map<String, SheetInfo> sheetInfoMap = null;
-  
+
   private void buildSheetInfoMap(CallingContext cc) throws IOException {
     if ( sheetInfoMap != null ) return;
 
@@ -522,7 +518,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     }
     Sheet existingSheet;
     GridRange range;
-    
+
     Map<String, SheetInfo> workingSheetInfoMap = new HashMap<String, SheetInfo>();
 
     Get req = spreadsheetService.spreadsheets().get(objectEntity.getSpreadsheetKey());
@@ -534,14 +530,14 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     sheetInfo.sheetId = Integer.valueOf(objectEntity.getTopLevelWorksheetId());
     sheetInfo.headers = headerFormatter.generateHeaders(form, form.getTopLevelGroupElement(), null);
     sheetInfo.headerTypes = headerFormatter.getHeaderTypes();
-    
+
     workingSheetInfoMap.put(objectEntity.getTopLevelWorksheetId(), sheetInfo);
-    
+
     // build gridRange request for top-level sheet headers
     existingSheet = sheetMap.get(sheetInfo.sheetId);
-    ranges.add(existingSheet.getProperties().getTitle() + "!R1C1:R1C" 
+    ranges.add(existingSheet.getProperties().getTitle() + "!R1C1:R1C"
     + Integer.valueOf(existingSheet.getProperties().getGridProperties().getColumnCount()));
-    
+
     // build gridRange request for repeat group sheet headers
     for (GoogleSpreadsheet2RepeatParameterTable tableId : repeatElementEntities) {
 
@@ -553,11 +549,11 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
       sheetInfo.sheetId = Integer.valueOf(tableId.getWorksheetId());
       sheetInfo.headers =  headerFormatter.generateHeaders(form, element, null);
       sheetInfo.headerTypes = headerFormatter.getHeaderTypes();
-      
+
       workingSheetInfoMap.put(tableId.getWorksheetId(), sheetInfo);
-      
+
       existingSheet = sheetMap.get(sheetInfo.sheetId);
-      ranges.add(existingSheet.getProperties().getTitle() + "!R1C1:R1C" 
+      ranges.add(existingSheet.getProperties().getTitle() + "!R1C1:R1C"
           + Integer.valueOf(existingSheet.getProperties().getGridProperties().getColumnCount()));
     }
     req.setRanges(ranges);
@@ -567,7 +563,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     for ( Sheet sheet : entry.getSheets() ) {
       Integer id = sheet.getProperties().getSheetId();
       sheetInfo = workingSheetInfoMap.get(Integer.toString(id));
-      
+
       for ( GridData data : sheet.getData() ) {
         // there may be extra entries to ignore
         if ( data == null ) {
@@ -576,7 +572,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
         Integer startCol = 0;
         // there may be extra rows to ignore
         List<CellData> cells = data.getRowData().get(0).getValues();
-        
+
         for ( CellData cell : cells ) {
           if ( cell == null ) {
             startCol++;
@@ -600,17 +596,17 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
     }
     sheetInfoMap = workingSheetInfoMap;
   }
-  
+
   @Override
   protected void insertData(Submission submission, CallingContext cc)
       throws ODKExternalServiceException {
     if (getReady()) {
       try {
         buildSheetInfoMap(cc);
-        
+
         SheetInfo sheetInfo;
         List<Request> requests = new ArrayList<Request>();
-        
+
         // upload base submission values
         sheetInfo = sheetInfoMap.get(objectEntity.getTopLevelWorksheetId());
         AppendCellsRequest acr = createAppendCellsRequest(submission, sheetInfo, cc);
@@ -621,7 +617,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
           FormElementKey elementKey = tableId.getFormElementKey();
           FormElementModel element = FormElementModel.retrieveFormElementModel(form, elementKey);
           sheetInfo = sheetInfoMap.get(tableId.getWorksheetId());
-          
+
           List<SubmissionValue> values = submission.findElementValue(element);
           for (SubmissionValue value : values) {
             if (value instanceof RepeatSubmissionType) {
@@ -638,19 +634,18 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
             }
           }
         }
-        
+
         if ( !requests.isEmpty() ) {
           BatchUpdateSpreadsheetRequest req = new BatchUpdateSpreadsheetRequest();
           req.setRequests(requests);
           req.setIncludeSpreadsheetInResponse(false);
-          BatchUpdateSpreadsheetResponse rsp = 
+          BatchUpdateSpreadsheetResponse rsp =
               spreadsheetService.spreadsheets().batchUpdate(objectEntity.getSpreadsheetKey(), req).execute();
         }
 
       } catch (Exception e) {
-        e.printStackTrace();
         logger.error("Unable to insert data into spreadsheet " + objectEntity.getSpreadsheetName()
-            + " exception: " + e.getMessage());
+            + " exception: " + e.getMessage(), e);
         throw new ODKExternalServiceException(e);
       }
     }
@@ -659,11 +654,11 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
   /**
    * Creates the request to append the data in the given submissionSet as a new entry (i.e. a new row)
    * in the given worksheet, including only the data specified by headers.
-   * 
+   *
    * @param submissionSet
    *          the set of data from a single submission
    * @param sheetInfo
-   *          encapsulates information about the Sheet (worksheet) and the 
+   *          encapsulates information about the Sheet (worksheet) and the
    *          list of headers we are publishing into, and the mapping between the two.
    * @param cc
    *          the calling context
@@ -723,11 +718,11 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
       }
       cellReorderMap.put(newCol, cellData);
     }
-    
+
     if ( minNewCol < 0 ) {
       throw new IllegalStateException("Expected columns in row to start at index 0");
     }
-    
+
     AppendCellsRequest acr = new AppendCellsRequest();
     acr.setFields("*");
     acr.setSheetId(sheetInfo.sheetId);

--- a/src/main/java/org/opendatakit/aggregate/externalservice/REDCapServer.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/REDCapServer.java
@@ -33,8 +33,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -80,7 +80,7 @@ import org.xml.sax.SAXException;
 
 
 public class REDCapServer extends AbstractExternalService implements ExternalService {
-  private static final Log logger = LogFactory.getLog(FusionTable.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(FusionTable.class.getName());
 
   /**
    * Datastore entity specific to this type of external service

--- a/src/main/java/org/opendatakit/aggregate/form/FormDefinition.java
+++ b/src/main/java/org/opendatakit/aggregate/form/FormDefinition.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.datamodel.FormDataModel;
 import org.opendatakit.aggregate.datamodel.FormDataModel.ElementType;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
@@ -63,7 +63,7 @@ import org.opendatakit.common.web.CallingContext;
  */
 public class FormDefinition {
 
-    private static final Log logger = LogFactory.getLog(FormDefinition.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(FormDefinition.class.getName());
 
     /**
      * Map from the uriSubmissionDataModel key (uuid) to the FormDefinition.

--- a/src/main/java/org/opendatakit/aggregate/form/FormFactory.java
+++ b/src/main/java/org/opendatakit/aggregate/form/FormFactory.java
@@ -16,8 +16,8 @@
 
 package org.opendatakit.aggregate.form;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.exception.ODKConversionException;
 import org.opendatakit.aggregate.exception.ODKFormNotFoundException;
 import org.opendatakit.aggregate.parser.FormParserForJavaRosa;
@@ -44,7 +44,7 @@ import java.util.*;
  */
 public class FormFactory {
 
-  private static final Log logger = LogFactory.getLog(FormFactory.class);
+  private static final Logger logger = LoggerFactory.getLogger(FormFactory.class);
 
   private static long cacheTimestamp = 0L;
   private static final List<IForm> cache = new LinkedList<IForm>();

--- a/src/main/java/org/opendatakit/aggregate/odktables/DataManager.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/DataManager.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.odktables.exception.BadColumnNameException;
 import org.opendatakit.aggregate.odktables.exception.ETagMismatchException;
 import org.opendatakit.aggregate.odktables.exception.InconsistentStateException;
@@ -76,7 +76,7 @@ import org.opendatakit.common.web.constants.BasicConsts;
 
 public class DataManager {
 
-  private static final Log logger = LogFactory.getLog(DataManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(DataManager.class);
 
   public static class WebsafeRows {
     public final List<Row> rows;
@@ -163,7 +163,7 @@ public class DataManager {
     List<Entity> logEntries = query.execute();
 
     for (Entity logEntity : logEntries) {
-      // Log entries maintain the history of previous rowETags
+      // Logger entries maintain the history of previous rowETags
       // Chain back through that to get the previous log record.
       // If the previous rowETag is null, it means that the rowId
       // did not exist prior to this log entry.

--- a/src/main/java/org/opendatakit/aggregate/odktables/FileManager.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/FileManager.java
@@ -18,8 +18,8 @@ package org.opendatakit.aggregate.odktables;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.odktables.exception.FileNotFoundException;
 import org.opendatakit.aggregate.odktables.relation.DbManifestETags;
 import org.opendatakit.aggregate.odktables.relation.DbManifestETags.DbManifestETagEntity;
@@ -47,7 +47,7 @@ import org.opendatakit.common.web.constants.BasicConsts;
  */
 public class FileManager {
 
-  private static final Log LOGGER = LogFactory.getLog(FileManager.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileManager.class);
 
   /**
    * The name of the folder that contains the files associated with a table in

--- a/src/main/java/org/opendatakit/aggregate/odktables/FileManifestManager.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/FileManifestManager.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.odktables.impl.api.FileServiceImpl;
 import org.opendatakit.aggregate.odktables.relation.DbTableFileInfo;
@@ -46,7 +46,7 @@ public class FileManifestManager {
   private String appId;
   private String odkClientVersion;
   private CallingContext cc;
-  private Log log;
+  private Logger log;
 
   public FileManifestManager(String appId, String odkClientVersion, CallingContext cc) {
     Validate.notEmpty(appId);
@@ -55,7 +55,7 @@ public class FileManifestManager {
     // TODO: verify that appId matches what stored in
     // ServerPreferencesProperties...
     this.cc = cc;
-    this.log = LogFactory.getLog(FileManifestManager.class);
+    this.log = LoggerFactory.getLogger(FileManifestManager.class);
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/odktables/OdkTablesLockTemplate.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/OdkTablesLockTemplate.java
@@ -19,8 +19,8 @@ package org.opendatakit.aggregate.odktables;
 import java.util.Random;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.Datastore;
 import org.opendatakit.common.persistence.TaskLock;
 import org.opendatakit.common.persistence.exception.ODKTaskLockException;
@@ -62,7 +62,7 @@ public class OdkTablesLockTemplate {
   private DelayStrategy delay;
   private long maxBackoffMs;
   private Random rand;
-  private Log log;
+  private Logger log;
 
   /**
    * File-manager-specific lock for accessing app-level, table-level and
@@ -109,7 +109,7 @@ public class OdkTablesLockTemplate {
     this.delay = delay;
     this.maxBackoffMs = delay.getBaseBackOffTime();
     this.rand = new Random();
-    this.log = LogFactory.getLog(FileManifestManager.class);
+    this.log = LoggerFactory.getLogger(FileManifestManager.class);
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/odktables/entity/UtilTransforms.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/entity/UtilTransforms.java
@@ -19,8 +19,8 @@ package org.opendatakit.aggregate.odktables.entity;
 import java.util.Date;
 import java.util.HashMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.odktables.ColumnClient;
 import org.opendatakit.aggregate.client.odktables.RowClient;
 import org.opendatakit.aggregate.client.odktables.RowFilterScopeClient;
@@ -51,7 +51,7 @@ import org.opendatakit.common.utils.WebUtils;
  *
  */
 public class UtilTransforms {
-  private static final Log log = LogFactory.getLog(UtilTransforms.class);
+  private static final Logger log = LoggerFactory.getLogger(UtilTransforms.class);
 
   /**
    * Transform the object into a server-side Column object.

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/FileManifestServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/FileManifestServiceImpl.java
@@ -26,8 +26,8 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.odktables.FileManifestManager;
 import org.opendatakit.aggregate.odktables.api.FileManifestService;
@@ -107,7 +107,7 @@ public class FileManifestServiceImpl implements FileManifestService {
       manifest = manifestManager.getManifestForAppLevelFiles();
 
     } catch (ODKDatastoreException e) {
-      Log log = LogFactory.getLog(FileManifestServiceImpl.class);
+      Logger log = LoggerFactory.getLogger(FileManifestServiceImpl.class);
       log.error("Datastore exception in getting the file manifest");
       e.printStackTrace();
     }
@@ -124,7 +124,7 @@ public class FileManifestServiceImpl implements FileManifestService {
         eTagEntity.setManifestETag(newETag);
         eTagEntity.put(cc);
       } else if (!newETag.equals(eTagEntity.getManifestETag())) {
-        Log log = LogFactory.getLog(FileManifestServiceImpl.class);
+        Logger log = LoggerFactory.getLogger(FileManifestServiceImpl.class);
         log.error("App-level Manifest ETag does not match computed value!");
         eTagEntity.setManifestETag(newETag);
         eTagEntity.put(cc);
@@ -180,7 +180,7 @@ public class FileManifestServiceImpl implements FileManifestService {
       // we want just the files for the table.
       manifest = manifestManager.getManifestForTable(tableId);
     } catch (ODKDatastoreException e) {
-      Log log = LogFactory.getLog(FileManifestServiceImpl.class);
+      Logger log = LoggerFactory.getLogger(FileManifestServiceImpl.class);
       log.error("Datastore exception in getting the file manifest");
       e.printStackTrace();
     }
@@ -197,7 +197,7 @@ public class FileManifestServiceImpl implements FileManifestService {
         eTagEntity.setManifestETag(newETag);
         eTagEntity.put(cc);
       } else if (!newETag.equals(eTagEntity.getManifestETag())) {
-        Log log = LogFactory.getLog(FileManifestServiceImpl.class);
+        Logger log = LoggerFactory.getLogger(FileManifestServiceImpl.class);
         log.error("Table-level (" + tableId + ") Manifest ETag does not match computed value!");
         eTagEntity.setManifestETag(newETag);
         eTagEntity.put(cc);

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/FileServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/FileServiceImpl.java
@@ -33,7 +33,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.odktables.ConfigFileChangeDetail;
 import org.opendatakit.aggregate.odktables.FileContentInfo;
@@ -193,7 +193,7 @@ public class FileServiceImpl implements FileService {
           DbInstallationInteractionLog.recordChangeConfigurationEntry(installationId, tableId, cc);
         }
       } catch ( Exception e ) {
-        LogFactory.getLog(FileServiceImpl.class).error("Unable to recordChangeConfigurationEntry", e);
+        LoggerFactory.getLogger(FileServiceImpl.class).error("Unable to recordChangeConfigurationEntry", e);
       }
     }
 
@@ -249,7 +249,7 @@ public class FileServiceImpl implements FileService {
           DbInstallationInteractionLog.recordChangeConfigurationEntry(installationId, tableId, cc);
         }
       } catch ( Exception e ) {
-        LogFactory.getLog(FileServiceImpl.class).error("Unable to recordChangeConfigurationEntry", e);
+        LoggerFactory.getLogger(FileServiceImpl.class).error("Unable to recordChangeConfigurationEntry", e);
       }
     }
 

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/InstanceFileServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/InstanceFileServiceImpl.java
@@ -35,8 +35,8 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.wink.common.model.multipart.BufferedOutMultiPart;
 import org.apache.wink.common.model.multipart.InMultiPart;
 import org.apache.wink.common.model.multipart.OutPart;
@@ -176,7 +176,7 @@ public class InstanceFileServiceImpl implements InstanceFileService {
         eTagEntity.setManifestETag(newETag);
         eTagEntity.put(cc);
       } else if (!newETag.equals(eTagEntity.getManifestETag())) {
-        Log log = LogFactory.getLog(FileManifestServiceImpl.class);
+        Logger log = LoggerFactory.getLogger(FileManifestServiceImpl.class);
         log.error("TableInstance (" + tableId + "," + rowId
             + ") Manifest ETag does not match computed value!");
         eTagEntity.setManifestETag(newETag);

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/OdkTablesImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/OdkTablesImpl.java
@@ -16,8 +16,8 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.odktables.api.OdkTables;
 import org.opendatakit.aggregate.odktables.exception.AppNameMismatchException;
@@ -93,7 +93,7 @@ public class OdkTablesImpl implements OdkTables {
             .header("Access-Control-Allow-Credentials", "true").build();
       }
     } catch (ODKDatastoreException e) {
-      Log log = LogFactory.getLog(OdkTablesImpl.class);
+      Logger log = LoggerFactory.getLogger(OdkTablesImpl.class);
       log.error("Datastore exception in getting the file manifest");
       e.printStackTrace();
     }
@@ -140,7 +140,7 @@ public class OdkTablesImpl implements OdkTables {
           DbInstallationInteractionLog.recordVerificationEntry(installationId, cc);
         }
       } catch ( Exception e ) {
-        LogFactory.getLog(OdkTablesImpl.class).warn("Unable to write verification log entry for " +
+        LoggerFactory.getLogger(OdkTablesImpl.class).warn("Unable to write verification log entry for " +
                     installationId + " user " + cc.getCurrentUser().getUriUser(), e);
       }
 
@@ -149,7 +149,7 @@ public class OdkTablesImpl implements OdkTables {
           .header("Access-Control-Allow-Origin", "*")
           .header("Access-Control-Allow-Credentials", "true").build();
     } catch ( Exception e ) {
-      Log log = LogFactory.getLog(OdkTablesImpl.class);
+      Logger log = LoggerFactory.getLogger(OdkTablesImpl.class);
       log.error("Exception retrieving user privileges");
       e.printStackTrace();
 
@@ -200,7 +200,7 @@ public class OdkTablesImpl implements OdkTables {
           try {
             allUsers = SecurityServiceUtil.getAllUsers(true, cc);
           } catch (AccessDeniedException e) {
-            Log log = LogFactory.getLog(OdkTablesImpl.class);
+            Logger log = LoggerFactory.getLogger(OdkTablesImpl.class);
             log.error("AccessDeniedException retrieving user list");
             e.printStackTrace();
 
@@ -210,7 +210,7 @@ public class OdkTablesImpl implements OdkTables {
                 .header("Access-Control-Allow-Origin", "*")
                 .header("Access-Control-Allow-Credentials", "true").build();
           } catch (DatastoreFailureException e) {
-            Log log = LogFactory.getLog(OdkTablesImpl.class);
+            Logger log = LoggerFactory.getLogger(OdkTablesImpl.class);
             log.error("DatastoreFailureException retrieving user list");
             e.printStackTrace();
 
@@ -261,7 +261,7 @@ public class OdkTablesImpl implements OdkTables {
               mapper.writeValueAsString(body), cc);
         }
       } catch ( Exception e ) {
-        LogFactory.getLog(OdkTablesImpl.class).error("(ignored) Unable to recordChangeConfigurationEntry", e);
+        LoggerFactory.getLogger(OdkTablesImpl.class).error("(ignored) Unable to recordChangeConfigurationEntry", e);
       }
     }
     

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/RealizedTableServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/RealizedTableServiceImpl.java
@@ -28,8 +28,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.odktables.TableManager;
 import org.opendatakit.aggregate.odktables.api.DataService;
 import org.opendatakit.aggregate.odktables.api.DiffService;
@@ -57,7 +57,7 @@ import org.opendatakit.common.web.CallingContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RealizedTableServiceImpl implements RealizedTableService {
-  private static final Log logger = LogFactory.getLog(RealizedTableServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(RealizedTableServiceImpl.class);
   
   private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -112,7 +112,7 @@ public class RealizedTableServiceImpl implements RealizedTableService {
           DbInstallationInteractionLog.recordChangeConfigurationEntry(installationId, tableId, cc);
         }
       } catch ( Exception e ) {
-        LogFactory.getLog(FileServiceImpl.class).error("Unable to recordChangeConfigurationEntry", e);
+        LoggerFactory.getLogger(FileServiceImpl.class).error("Unable to recordChangeConfigurationEntry", e);
       }
     }
 
@@ -205,7 +205,7 @@ public class RealizedTableServiceImpl implements RealizedTableService {
           DbInstallationInteractionLog.recordSyncStatusEntry(installationId, tableId, mapper.writeValueAsString(syncDetails), cc);
         }
       } catch ( Exception e ) {
-        LogFactory.getLog(RealizedTableServiceImpl.class).error("Unable to recordSyncStatusEntry", e);
+        LoggerFactory.getLogger(RealizedTableServiceImpl.class).error("Unable to recordSyncStatusEntry", e);
       }
     }
 

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/TableServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/TableServiceImpl.java
@@ -43,8 +43,8 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.odktables.ConfigFileChangeDetail;
 import org.opendatakit.aggregate.odktables.FileContentInfo;
 import org.opendatakit.aggregate.odktables.FileManager;
@@ -91,7 +91,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TableServiceImpl implements TableService {
-  private static final Log logger = LogFactory.getLog(TableServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(TableServiceImpl.class);
 
   private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/wink/ContentEncodingResponseFilter.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/wink/ContentEncodingResponseFilter.java
@@ -59,8 +59,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.ext.RuntimeDelegate;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.wink.common.internal.http.AcceptEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,7 +96,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ContentEncodingResponseFilter implements Filter {
 
-  private static final Log log = LogFactory.getLog(ContentEncodingResponseFilter.class);
+  private static final Logger log = LoggerFactory.getLogger(ContentEncodingResponseFilter.class);
 
     private final static Logger                         logger                       =
                                                                                          LoggerFactory

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/wink/GaeAwareContentEncodingRequestFilter.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/wink/GaeAwareContentEncodingRequestFilter.java
@@ -24,8 +24,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.wink.server.internal.servlet.contentencode.ContentEncodingRequestFilter;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.common.security.Realm;
@@ -34,7 +34,7 @@ import org.opendatakit.common.web.CallingContext;
 
 public class GaeAwareContentEncodingRequestFilter extends ContentEncodingRequestFilter {
 
-  private static final Log logger = LogFactory.getLog(GaeAwareContentEncodingRequestFilter.class);
+  private static final Logger logger = LoggerFactory.getLogger(GaeAwareContentEncodingRequestFilter.class);
 
   @Override
   public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/wink/GaeAwareContentEncodingResponseFilter.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/wink/GaeAwareContentEncodingResponseFilter.java
@@ -24,8 +24,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.common.security.Realm;
 import org.opendatakit.common.security.UserService;
@@ -33,7 +33,7 @@ import org.opendatakit.common.web.CallingContext;
 
 public class GaeAwareContentEncodingResponseFilter extends ContentEncodingResponseFilter {
 
-  private static final Log logger = LogFactory.getLog(GaeAwareContentEncodingResponseFilter.class);
+  private static final Logger logger = LoggerFactory.getLogger(GaeAwareContentEncodingResponseFilter.class);
 
   @Override
   public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,

--- a/src/main/java/org/opendatakit/aggregate/odktables/importexport/CsvUtil.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/importexport/CsvUtil.java
@@ -19,7 +19,7 @@ package org.opendatakit.aggregate.odktables.importexport;
 import java.io.BufferedReader;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.exception.BadColumnNameExceptionClient;
 import org.opendatakit.aggregate.client.exception.ETagMismatchExceptionClient;
 import org.opendatakit.aggregate.client.exception.EntityNotFoundExceptionClient;
@@ -62,7 +62,7 @@ public class CsvUtil {
   public boolean importNewTable(BufferedReader buffReader, String tableName, CallingContext cc)
       throws ImportFromCSVExceptionClient, ETagMismatchExceptionClient,
       PermissionDeniedExceptionClient, EntityNotFoundExceptionClient, BadColumnNameExceptionClient {
-    LogFactory.getLog(getClass()).error("importNewTable out of date and is unimplemented!");
+    LoggerFactory.getLogger(getClass()).error("importNewTable out of date and is unimplemented!");
     return false;
     // List<ColumnClient> columns = new ArrayList<ColumnClient>();
     // try {

--- a/src/main/java/org/opendatakit/aggregate/odktables/relation/DbTableDefinitions.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/relation/DbTableDefinitions.java
@@ -19,7 +19,7 @@ package org.opendatakit.aggregate.odktables.relation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.ermodel.Entity;
 import org.opendatakit.common.ermodel.Query;
 import org.opendatakit.common.ermodel.Relation;
@@ -151,7 +151,7 @@ public class DbTableDefinitions extends Relation {
     }
 
     if (list.size() != 1) {
-      LogFactory.getLog(DbTableDefinitions.class.getName()).warn(
+      LoggerFactory.getLogger(DbTableDefinitions.class.getName()).warn(
           "Multiple DbTableDefinitions records for table id " + tableId + " and schemaETag "
               + schemaETag);
     }

--- a/src/main/java/org/opendatakit/aggregate/odktables/relation/EntityCreator.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/relation/EntityCreator.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.odktables.Sequencer;
 import org.opendatakit.aggregate.odktables.exception.BadColumnNameException;
 import org.opendatakit.aggregate.odktables.relation.DbColumnDefinitions.DbColumnDefinitionsEntity;
@@ -55,7 +55,7 @@ import org.opendatakit.common.web.CallingContext;
  */
 
 public class EntityCreator {
-  public static final Log log = LogFactory.getLog(EntityCreator.class);
+  public static final Logger log = LoggerFactory.getLogger(EntityCreator.class);
 
   public static final int INITIAL_MODIFICATION_NUMBER = 1;
 

--- a/src/main/java/org/opendatakit/aggregate/odktables/security/OdkTablesUserInfoTable.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/security/OdkTablesUserInfoTable.java
@@ -20,8 +20,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.odktables.FileManifestManager;
 import org.opendatakit.aggregate.odktables.OdkTablesLockTemplate;
 import org.opendatakit.aggregate.odktables.ODKTablesTaskLockType;
@@ -221,7 +221,7 @@ public class OdkTablesUserInfoTable extends CommonFieldsBase implements OdkTable
 
     OdkTablesUserInfoTable prototype = OdkTablesUserInfoTable.assertRelation(cc);
 
-    Log log = LogFactory.getLog(FileManifestManager.class);
+    Logger log = LoggerFactory.getLogger(FileManifestManager.class);
 
     log.info("TablesUserPermissionsImpl: " + uriUser);
 

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.DataBinding;
 import org.javarosa.core.model.FormDef;
@@ -63,7 +63,7 @@ import org.opendatakit.common.web.constants.BasicConsts;
 public class BaseFormParserForJavaRosa {
 
   private static final String LEADING_QUESTION_XML_PATTERN = "^[^<]*<\\s*\\?\\s*xml.*";
-  private static final Log log = LogFactory.getLog(BaseFormParserForJavaRosa.class.getName());
+  private static final Logger log = LoggerFactory.getLogger(BaseFormParserForJavaRosa.class.getName());
 
   private static boolean isJavaRosaInitialized = false;
   /**

--- a/src/main/java/org/opendatakit/aggregate/parser/FormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/FormParserForJavaRosa.java
@@ -30,8 +30,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.javarosa.core.model.instance.TreeElement;
 import org.opendatakit.aggregate.constants.ParserConsts;
 import org.opendatakit.aggregate.constants.ServletConsts;
@@ -75,7 +75,7 @@ import org.opendatakit.common.web.CallingContext;
  */
 public class FormParserForJavaRosa extends BaseFormParserForJavaRosa {
 
-  private static final Log log = LogFactory.getLog(FormParserForJavaRosa.class.getName());
+  private static final Logger log = LoggerFactory.getLogger(FormParserForJavaRosa.class.getName());
 
   private static final long FIFTEEN_MINUTES_IN_MILLISECONDS = 15 * 60 * 1000L;
 

--- a/src/main/java/org/opendatakit/aggregate/parser/NamingSet.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/NamingSet.java
@@ -21,8 +21,8 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.Datastore;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.security.User;
@@ -46,7 +46,7 @@ import org.opendatakit.common.web.CallingContext;
  */
 final class NamingSet {
   private static final String DROP_CHARS = "AEIOUY";
-  private static final Log logger = LogFactory.getLog(NamingSet.class);
+  private static final Logger logger = LoggerFactory.getLogger(NamingSet.class);
 
   private StringBuilder dbg = null;
   private int idxResolveNames = 0;

--- a/src/main/java/org/opendatakit/aggregate/parser/SubmissionParser.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/SubmissionParser.java
@@ -31,8 +31,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.ParserConsts;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
@@ -392,7 +392,7 @@ public class SubmissionParser {
         try {
           submission = new Submission(fi, form, cc);
         } catch (ODKDatastoreException e) {
-          Log logger = LogFactory.getLog(Submission.class);
+          Logger logger = LoggerFactory.getLogger(Submission.class);
           e.printStackTrace();
           logger.error("Unable to reconstruct submission for " + fi.getSchemaName() + "."
               + fi.getTableName() + " uri " + fi.getUri());

--- a/src/main/java/org/opendatakit/aggregate/query/submission/QueryByDateRange.java
+++ b/src/main/java/org/opendatakit/aggregate/query/submission/QueryByDateRange.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.datamodel.TopLevelDynamicBase;
 import org.opendatakit.aggregate.exception.ODKIncompleteSubmissionData;
 import org.opendatakit.aggregate.form.IForm;
@@ -115,7 +115,7 @@ public class QueryByDateRange extends QueryBase {
       try {
         retrievedSubmissions.add(new Submission((TopLevelDynamicBase) subEntity, getForm(), cc));
       } catch ( ODKDatastoreException e ) {
-        Log logger = LogFactory.getLog(QueryByUIFilterGroup.class);
+        Logger logger = LoggerFactory.getLogger(QueryByUIFilterGroup.class);
         e.printStackTrace();
         logger.error("Unable to reconstruct submission for " + 
             subEntity.getSchemaName() + "." + subEntity.getTableName() + " uri " + subEntity.getUri());

--- a/src/main/java/org/opendatakit/aggregate/query/submission/QueryByUIFilterGroup.java
+++ b/src/main/java/org/opendatakit/aggregate/query/submission/QueryByUIFilterGroup.java
@@ -22,8 +22,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.filter.Filter;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.client.filter.RowFilter;
@@ -225,7 +225,7 @@ public class QueryByUIFilterGroup extends QueryBase {
         Submission sub = new Submission((TopLevelDynamicBase) subEntity, getForm(), cc);
         retrievedSubmissions.add(sub);
       } catch (ODKDatastoreException e ) {
-        Log logger = LogFactory.getLog(QueryByUIFilterGroup.class);
+        Logger logger = LoggerFactory.getLogger(QueryByUIFilterGroup.class);
         e.printStackTrace();
         logger.error("Unable to reconstruct submission for " + 
             subEntity.getSchemaName() + "." + subEntity.getTableName() + " uri " + subEntity.getUri());
@@ -367,7 +367,7 @@ public class QueryByUIFilterGroup extends QueryBase {
         SubmissionKey subKey = sub.constructSubmissionKey(fem);
         submissionList.add(new SubmissionUI(row.getFormattedValues(), subKey.toString()));
       } catch ( ODKDatastoreException e ) {
-        Log logger = LogFactory.getLog(QueryByUIFilterGroup.class);
+        Logger logger = LoggerFactory.getLogger(QueryByUIFilterGroup.class);
         e.printStackTrace();
         logger.error("Unable to reconstruct submission for " + 
             subEntity.getSchemaName() + "." + subEntity.getTableName() + " uri " + subEntity.getUri());

--- a/src/main/java/org/opendatakit/aggregate/server/FormServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/FormServiceImpl.java
@@ -26,8 +26,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -64,7 +64,7 @@ import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
 public class FormServiceImpl extends RemoteServiceServlet implements
     org.opendatakit.aggregate.client.form.FormService {
-  private static final Log logger = LogFactory.getLog(FormServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(FormServiceImpl.class);
 
   /**
    * Serial number for serialization
@@ -125,10 +125,10 @@ public class FormServiceImpl extends RemoteServiceServlet implements
       return formSummaries;
 
     } catch (ODKOverQuotaException e) {
-      logger.error(e);
+      logger.error("Over quota failure", e);
       throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
-      logger.error(e);
+      logger.error("Datastore failure", e);
       throw new DatastoreFailureException();
     } catch (Throwable t) {
       logger.error("Possible corruption", t);

--- a/src/main/java/org/opendatakit/aggregate/server/PreferenceServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/PreferenceServiceImpl.java
@@ -18,8 +18,8 @@ package org.opendatakit.aggregate.server;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.client.preferences.PreferenceSummary;
@@ -37,7 +37,7 @@ import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 public class PreferenceServiceImpl extends RemoteServiceServlet implements
     org.opendatakit.aggregate.client.preferences.PreferenceService {
 
-  private static final Log log = LogFactory.getLog(PreferenceServiceImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(PreferenceServiceImpl.class);
   /**
    * Serialization Identifier
    */

--- a/src/main/java/org/opendatakit/aggregate/server/ServerOdkTablesUtil.java
+++ b/src/main/java/org/opendatakit/aggregate/server/ServerOdkTablesUtil.java
@@ -19,8 +19,8 @@ package org.opendatakit.aggregate.server;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.exception.BadColumnNameExceptionClient;
 import org.opendatakit.aggregate.client.exception.ETagMismatchExceptionClient;
 import org.opendatakit.aggregate.client.exception.EntityNotFoundExceptionClient;
@@ -77,7 +77,7 @@ public class ServerOdkTablesUtil {
   public static TableEntryClient createTable(String appId, String tableId, TableDefinitionClient definition,
       TablesUserPermissions userPermissions, CallingContext cc) throws DatastoreFailureException,
       TableAlreadyExistsExceptionClient, PermissionDeniedExceptionClient, ETagMismatchException {
-    Log logger = LogFactory.getLog(ServerOdkTablesUtil.class);
+    Logger logger = LoggerFactory.getLogger(ServerOdkTablesUtil.class);
     // TODO: add access control stuff
     // Have to be careful of all the transforms going on here.
     // Make sure they actually work as expected!

--- a/src/main/java/org/opendatakit/aggregate/server/ServerTableServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/ServerTableServiceImpl.java
@@ -17,8 +17,8 @@
 package org.opendatakit.aggregate.server;
 
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.PermissionDeniedExceptionClient;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -54,7 +54,7 @@ public class ServerTableServiceImpl extends RemoteServiceServlet implements Serv
    *
    */
   private static final long serialVersionUID = 329170770895918034L;
-  private static final Log logger = LogFactory.getLog(ServerTableServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(ServerTableServiceImpl.class);
 
   @Override
   public ArrayList<TableEntryClient> getTables() throws AccessDeniedException, RequestFailureException,

--- a/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
@@ -24,8 +24,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
@@ -50,7 +50,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  */
 public class AggregateHtmlServlet extends ServletUtilBase {
 
-  private static final Log logger = LogFactory.getLog(AggregateHtmlServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(AggregateHtmlServlet.class);
   /**
      *
      */

--- a/src/main/java/org/opendatakit/aggregate/servlet/BinaryDataServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/BinaryDataServlet.java
@@ -25,8 +25,8 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.constants.ErrorConsts;
@@ -58,7 +58,7 @@ public class BinaryDataServlet extends ServletUtilBase {
 
   private static final String NOT_BINARY_OBJECT = "Requested element is not a binary object";
 
-  private static final Log logger = LogFactory.getLog(BinaryDataServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(BinaryDataServlet.class);
 
   /**
    * Serial number for serialization

--- a/src/main/java/org/opendatakit/aggregate/servlet/ClearSessionThenLoginServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ClearSessionThenLoginServlet.java
@@ -57,7 +57,7 @@ public class ClearSessionThenLoginServlet extends ServletUtilBase {
     if (s != null) {
       s.invalidate();
       // insert delay to let this propagate out?
-      // attempt to fix non-responsiveness of the Log In
+      // attempt to fix non-responsiveness of the Logger In
       // button upon initial page load...
       try {
         Thread.sleep(1000L);

--- a/src/main/java/org/opendatakit/aggregate/servlet/EnketoAccountPrivateKeyUploadServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/EnketoAccountPrivateKeyUploadServlet.java
@@ -24,8 +24,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.constants.ServletConsts;
@@ -76,7 +76,7 @@ public class EnketoAccountPrivateKeyUploadServlet extends ServletUtilBase {
       + "         <td><input type=\"submit\" name=\"button\" class=\"gwt-Button\" value=\"Save\" /></td>"
       + "         <td />" + "    </tr>" + "    </table>\n" + "   </form>" + "<br></div>\n";
 
-  private static final Log logger = LogFactory.getLog(ServiceAccountPrivateKeyUploadServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(ServiceAccountPrivateKeyUploadServlet.class);
 
   /**
    * Handler for HTTP Get request to create xform upload page

--- a/src/main/java/org/opendatakit/aggregate/servlet/EnketoApiHandlerServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/EnketoApiHandlerServlet.java
@@ -28,8 +28,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.opendatakit.common.web.CallingContext;
@@ -37,7 +37,7 @@ import org.opendatakit.common.web.CallingContext;
 public class EnketoApiHandlerServlet extends ServletUtilBase {
 
   private static final long serialVersionUID = 5811797423869654357L;
-  private static final Log logger = LogFactory.getLog(AggregateHtmlServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(AggregateHtmlServlet.class);
 
   public static final String ADDR = UIConsts.ENKETO_API_HANDLER_ADDR;
   private final String USER_AGENT = "Mozilla/5.0";

--- a/src/main/java/org/opendatakit/aggregate/servlet/FormUploadServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/FormUploadServlet.java
@@ -26,8 +26,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.constants.HtmlUtil;
@@ -137,7 +137,7 @@ public class FormUploadServlet extends ServletUtilBase {
    */
   private static final String TITLE_OF_THE_XFORM = "Title of the Xform:";
 
-  private static final Log logger = LogFactory.getLog(FormUploadServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(FormUploadServlet.class);
 
   /**
    * Handler for HTTP Get request to create xform upload page

--- a/src/main/java/org/opendatakit/aggregate/servlet/GetUsersAndPermissionsServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/GetUsersAndPermissionsServlet.java
@@ -26,8 +26,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.constants.common.UIConsts;
@@ -64,7 +64,7 @@ public class GetUsersAndPermissionsServlet extends ServletUtilBase {
   public static final String ADDR = UIConsts.GET_USERS_AND_PERMS_CSV_SERVLET_ADDR;
 
   
-  private static final Log logger = LogFactory.getLog(GetUsersAndPermissionsServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(GetUsersAndPermissionsServlet.class);
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,

--- a/src/main/java/org/opendatakit/aggregate/servlet/LocalLoginPageServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/LocalLoginPageServlet.java
@@ -23,8 +23,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.web.constants.HtmlConsts;
 
 /**
@@ -36,7 +36,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  */
 public class LocalLoginPageServlet extends ServletUtilBase {
 
-  private static final Log logger = LogFactory.getLog(LocalLoginPageServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(LocalLoginPageServlet.class);
 
   /*
    * Standard fields

--- a/src/main/java/org/opendatakit/aggregate/servlet/MultimodeLoginPageServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/MultimodeLoginPageServlet.java
@@ -26,8 +26,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
@@ -46,7 +46,7 @@ public class MultimodeLoginPageServlet extends ServletUtilBase {
      *
      */
   private static final long serialVersionUID = -1036419513113652548L;
-  private static final Log logger = LogFactory.getLog(MultimodeLoginPageServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(MultimodeLoginPageServlet.class);
 
   public static final String ADDR = "multimode_login.html";
 

--- a/src/main/java/org/opendatakit/aggregate/servlet/ResetUsersAndPermissionsServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ResetUsersAndPermissionsServlet.java
@@ -32,8 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.constants.HtmlUtil;
@@ -136,7 +136,7 @@ public class ResetUsersAndPermissionsServlet extends ServletUtilBase {
       + " actions, such as deleting the super-user, or granting Site Administrator privileges to the anonymousUser</p>"
       + "</td></tr></tbody></table></div>\n";
   
-  private static final Log logger = LogFactory.getLog(ResetUsersAndPermissionsServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(ResetUsersAndPermissionsServlet.class);
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,

--- a/src/main/java/org/opendatakit/aggregate/servlet/ServiceAccountPrivateKeyUploadServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ServiceAccountPrivateKeyUploadServlet.java
@@ -27,8 +27,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.constants.ServletConsts;
@@ -111,7 +111,7 @@ public class ServiceAccountPrivateKeyUploadServlet extends ServletUtilBase {
       + "     </form>"
       + "<br></div>\n";
 
-  private static final Log logger = LogFactory.getLog(ServiceAccountPrivateKeyUploadServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(ServiceAccountPrivateKeyUploadServlet.class);
 
   /**
    * Handler for HTTP Get request to create xform upload page

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionServlet.java
@@ -29,8 +29,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.constants.ErrorConsts;
@@ -72,7 +72,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  */
 public class SubmissionServlet extends ServletUtilBase {
 
-  private static final Log logger = LogFactory.getLog(SubmissionServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(SubmissionServlet.class);
   /**
    * Serial number for serialization
    */

--- a/src/main/java/org/opendatakit/aggregate/servlet/UserManagePasswordsServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/UserManagePasswordsServlet.java
@@ -22,7 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.common.persistence.client.exception.DatastoreFailureException;
@@ -83,7 +83,7 @@ public class UserManagePasswordsServlet extends ServletUtilBase {
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
       IOException {
     if (req.getScheme().equals("http")) {
-      LogFactory.getLog(UserManagePasswordsServlet.class).warn("Setting user passwords over http");
+      LoggerFactory.getLogger(UserManagePasswordsServlet.class).warn("Setting user passwords over http");
     }
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 

--- a/src/main/java/org/opendatakit/aggregate/submission/Submission.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/Submission.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.common.FormElementNamespace;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
 import org.opendatakit.aggregate.datamodel.TopLevelDynamicBase;
@@ -259,7 +259,7 @@ public class Submission extends SubmissionSet {
     try {
       return new Submission(tle, form, cc);
     } catch (ODKDatastoreException e) {
-      Log logger = LogFactory.getLog(Submission.class);
+      Logger logger = LoggerFactory.getLogger(Submission.class);
       e.printStackTrace();
       logger.error("Unable to reconstruct submission for " + tle.getSchemaName() + "."
           + tle.getTableName() + " uri " + tle.getUri());

--- a/src/main/java/org/opendatakit/aggregate/submission/Submission.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/Submission.java
@@ -47,18 +47,11 @@ import org.opendatakit.common.web.CallingContext;
  * 
  */
 public class Submission extends SubmissionSet {
+  private static final Logger logger = LoggerFactory.getLogger(Submission.class);
 
   /**
    * Construct an empty submission for the given form definition.
    * 
-   * @param modelVersion
-   * @param uiVersion
-   * @param uriTopLevelGroup
-   *          -- override the primary key for the top level table.
-   * @param formDefinition
-   * @param submissionDate
-   * @param cc
-   * @throws ODKDatastoreException
    */
   public Submission(Long modelVersion, Long uiVersion, String uriTopLevelGroup, IForm form,
       Date submissionDate, CallingContext cc) throws ODKDatastoreException {
@@ -69,20 +62,13 @@ public class Submission extends SubmissionSet {
   /**
    * Construct a submission from an entity from the data store
    * 
-   * @param submission
-   *          - top level entity of the submission to restore
-   * @param formDefinition
-   *          - the definition of the form
-   * @param cc
-   *          - the CallingContext for this request
-   * @throws ODKDatastoreException
    */
   public Submission(TopLevelDynamicBase submission, IForm form, CallingContext cc)
       throws ODKDatastoreException {
     super(null, submission, form.getTopLevelGroupElement(), form, cc);
   }
 
-  public Submission(String uri, IForm form, CallingContext cc) throws ODKEntityNotFoundException,
+  public Submission(String uri, IForm form, CallingContext cc) throws
       ODKDatastoreException {
     super(null, (TopLevelDynamicBase) cc.getDatastore().getEntity(
         form.getTopLevelGroupElement().getFormDataModel().getBackingObjectPrototype(), uri,
@@ -91,7 +77,7 @@ public class Submission extends SubmissionSet {
 
   /**
    * Get the time that the submission was created/received
-   * 
+   *
    * @return date of submission
    */
   public Date getSubmissionDate() {
@@ -132,15 +118,6 @@ public class Submission extends SubmissionSet {
    * list. The resulting subset is then rendered (and the resulting row might
    * have no columns).
    * 
-   * @param types
-   *          -- list of e.g., (METADATA, VALUES) to be rendered.
-   * @param propertyNames
-   *          -- joint subset of property names to be rendered.
-   * @param elemFormatter
-   * @param includeParentUid
-   * @param cc
-   * @return rendered Row object
-   * @throws ODKDatastoreException
    */
   public Row getFormattedValuesAsRow(List<FormElementNamespace> types,
       List<FormElementModel> propertyNames, ElementFormatter elemFormatter,
@@ -165,7 +142,7 @@ public class Submission extends SubmissionSet {
       }
     }
 
-    List<FormElementModel> reducedProperties = new ArrayList<FormElementModel>();
+    List<FormElementModel> reducedProperties = new ArrayList<>();
     for (FormElementModel m : propertyNames) {
       if (m.isMetadata() && hasMeta) {
         reducedProperties.add(m);
@@ -181,17 +158,11 @@ public class Submission extends SubmissionSet {
    * Given the list of FormElementNamespaces to render, this renders the
    * namespaces in the order given.
    * 
-   * @param row
-   * @param types
-   * @param elemFormatter
-   * @param includeParentUid
-   * @param cc
-   * @throws ODKDatastoreException
    */
   public void getFormattedNamespaceValuesForRow(Row row, List<FormElementNamespace> types,
       ElementFormatter elemFormatter, boolean includeParentUid, CallingContext cc)
       throws ODKDatastoreException {
-    List<FormElementModel> elementList = new ArrayList<FormElementModel>();
+    List<FormElementModel> elementList = new ArrayList<>();
     // get the in-order list of all flattened elements within this submission
     // set...
     List<FormElementModel> allElements = getFormElements();
@@ -228,7 +199,7 @@ public class Submission extends SubmissionSet {
     return resolveSubmissionKeyBeginningAt(1, parts);
   }
 
-  public static final Submission fetchSubmission(List<SubmissionKeyPart> parts, CallingContext cc)
+  public static Submission fetchSubmission(List<SubmissionKeyPart> parts, CallingContext cc)
       throws ODKFormNotFoundException, ODKDatastoreException {
     if (parts == null || parts.size() == 0) {
       throw new IllegalArgumentException("submission key is empty");
@@ -259,10 +230,8 @@ public class Submission extends SubmissionSet {
     try {
       return new Submission(tle, form, cc);
     } catch (ODKDatastoreException e) {
-      Logger logger = LoggerFactory.getLogger(Submission.class);
-      e.printStackTrace();
       logger.error("Unable to reconstruct submission for " + tle.getSchemaName() + "."
-          + tle.getTableName() + " uri " + tle.getUri());
+          + tle.getTableName() + " uri " + tle.getUri(), e);
       
       if ( (e instanceof ODKEntityNotFoundException) ||
            (e instanceof ODKEnumeratedElementException) ) {
@@ -280,7 +249,7 @@ public class Submission extends SubmissionSet {
 
   }
 
-  public static final TopLevelDynamicBase fetchTopLevelSubmissionObject(List<SubmissionKeyPart> parts, CallingContext cc)
+  public static TopLevelDynamicBase fetchTopLevelSubmissionObject(List<SubmissionKeyPart> parts, CallingContext cc)
       throws ODKFormNotFoundException, ODKDatastoreException {
     if (parts == null || parts.size() == 0) {
       throw new IllegalArgumentException("submission key is empty");
@@ -305,9 +274,8 @@ public class Submission extends SubmissionSet {
 
     Datastore ds = cc.getDatastore();
     User user = cc.getCurrentUser();
-    TopLevelDynamicBase tle = (TopLevelDynamicBase) ds.getEntity(form.getTopLevelGroupElement()
-        .getFormDataModel().getBackingObjectPrototype(), tlg.getAuri(), user);
 
-    return tle;
+    return (TopLevelDynamicBase) ds.getEntity(form.getTopLevelGroupElement()
+        .getFormDataModel().getBackingObjectPrototype(), tlg.getAuri(), user);
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/submission/type/RepeatSubmissionType.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/RepeatSubmissionType.java
@@ -17,8 +17,8 @@
 
 package org.opendatakit.aggregate.submission.type;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.format.FormatConsts;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
 import org.opendatakit.aggregate.form.IForm;
@@ -46,7 +46,7 @@ import java.util.*;
  * @author mitchellsundt@gmail.com
  */
 public class RepeatSubmissionType implements SubmissionRepeat {
-  private static final Log LOGGER = LogFactory.getLog(RepeatSubmissionType.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(RepeatSubmissionType.class);
   /**
    * ODK identifier that uniquely identifies the form
    */

--- a/src/main/java/org/opendatakit/aggregate/task/CsvWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/CsvWorkerImpl.java
@@ -21,8 +21,8 @@ import java.io.PrintWriter;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.common.ExportStatus;
@@ -49,7 +49,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  */
 public class CsvWorkerImpl {
 
-  private final Log logger = LogFactory.getLog(CsvWorkerImpl.class);
+  private final Logger logger = LoggerFactory.getLogger(CsvWorkerImpl.class);
   private final IForm form;
   private final SubmissionKey persistentResultsKey;
   private final Long attemptCount;

--- a/src/main/java/org/opendatakit/aggregate/task/FormDeleteWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/FormDeleteWorkerImpl.java
@@ -20,8 +20,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.TaskLockType;
 import org.opendatakit.aggregate.constants.common.FormActionStatus;
 import org.opendatakit.aggregate.datamodel.TopLevelDynamicBase;
@@ -65,7 +65,7 @@ public class FormDeleteWorkerImpl {
   private final SubmissionKey miscTasksKey;
   private final CallingContext cc;
   private final String pFormIdLockId;
-  private final Log logger = LogFactory.getLog(FormDeleteWorkerImpl.class);
+  private final Logger logger = LoggerFactory.getLogger(FormDeleteWorkerImpl.class);
 
   public FormDeleteWorkerImpl(IForm form, SubmissionKey miscTasksKey, long attemptCount,
       CallingContext cc) {

--- a/src/main/java/org/opendatakit/aggregate/task/JsonFileWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/JsonFileWorkerImpl.java
@@ -21,8 +21,8 @@ import java.io.PrintWriter;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.common.BinaryOption;
@@ -50,7 +50,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  */
 public class JsonFileWorkerImpl {
 
-  private final Log logger = LogFactory.getLog(CsvWorkerImpl.class);
+  private final Logger logger = LoggerFactory.getLogger(CsvWorkerImpl.class);
   private final IForm form;
   private final SubmissionKey persistentResultsKey;
   private final Long attemptCount;

--- a/src/main/java/org/opendatakit/aggregate/task/KmlWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/KmlWorkerImpl.java
@@ -21,8 +21,8 @@ import java.io.PrintWriter;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.client.form.KmlSelection;
 import org.opendatakit.aggregate.constants.ServletConsts;
@@ -50,7 +50,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  */
 public class KmlWorkerImpl {
 
-  private final Log logger = LogFactory.getLog(KmlWorkerImpl.class);
+  private final Logger logger = LoggerFactory.getLogger(KmlWorkerImpl.class);
   private final IForm form;
   private final SubmissionKey persistentResultsKey;
   private final Long attemptCount;

--- a/src/main/java/org/opendatakit/aggregate/task/PurgeOlderSubmissionsWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/PurgeOlderSubmissionsWorkerImpl.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.constants.TaskLockType;
 import org.opendatakit.aggregate.constants.common.FormActionStatus;
@@ -78,7 +78,7 @@ public class PurgeOlderSubmissionsWorkerImpl {
   public final void purgeOlderSubmissions() throws ODKDatastoreException, ODKFormNotFoundException,
       ODKExternalServiceDependencyException {
 
-    Log logger = LogFactory.getLog(PurgeOlderSubmissionsWorkerImpl.class);
+    Logger logger = LoggerFactory.getLogger(PurgeOlderSubmissionsWorkerImpl.class);
     logger.info("Beginning Submissions Purge: " + miscTasksKey.toString() + " form "
         + form.getFormId());
 
@@ -159,7 +159,7 @@ public class PurgeOlderSubmissionsWorkerImpl {
   private void doMarkAsComplete(MiscTasks t) throws ODKEntityPersistException,
       ODKOverQuotaException {
 
-    Log logger = LogFactory.getLog(PurgeOlderSubmissionsWorkerImpl.class);
+    Logger logger = LoggerFactory.getLogger(PurgeOlderSubmissionsWorkerImpl.class);
     logger.info("Submissions Purge: " + miscTasksKey.toString() + " form "
         + form.getFormId() + " doMarkAsComplete");
 
@@ -183,7 +183,7 @@ public class PurgeOlderSubmissionsWorkerImpl {
     Datastore ds = cc.getDatastore();
     User user = cc.getCurrentUser();
 
-    Log logger = LogFactory.getLog(PurgeOlderSubmissionsWorkerImpl.class);
+    Logger logger = LoggerFactory.getLogger(PurgeOlderSubmissionsWorkerImpl.class);
 
     Map<String, String> rp = t.getRequestParameters();
     String purgeBeforeDateString = rp.get(PurgeOlderSubmissions.PURGE_DATE);

--- a/src/main/java/org/opendatakit/aggregate/task/UploadSubmissionsWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/UploadSubmissionsWorkerImpl.java
@@ -22,8 +22,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.constants.TaskLockType;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
@@ -77,7 +77,7 @@ public class UploadSubmissionsWorkerImpl {
   private static final int DELAY_BETWEEN_RELEASE_RETRIES = 1000;
   private static final int MAX_NUMBER_OF_RELEASE_RETRIES = 10;
 
-  private final Log logger = LogFactory.getLog(UploadSubmissionsWorkerImpl.class);
+  private final Logger logger = LoggerFactory.getLogger(UploadSubmissionsWorkerImpl.class);
   private final String lockId;
   private final CallingContext cc;
   private final boolean useLargerBatchSize;
@@ -336,7 +336,7 @@ public class UploadSubmissionsWorkerImpl {
       // the PAUSED state.
       if (pFsc.getOperationalStatus() != OperationalStatus.BAD_CREDENTIALS) {
         // An authorization failure should have set
-        // the BAD_CREDENTIALS state. Log warning and do it now.
+        // the BAD_CREDENTIALS state. Logger warning and do it now.
         logger.warn("ODKExternalServiceCredentialsException but not yet in BAD_CREDENTIALS state!");
         pFsc.setOperationalStatus(OperationalStatus.BAD_CREDENTIALS);
         try {

--- a/src/main/java/org/opendatakit/aggregate/task/WatchdogWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/WatchdogWorkerImpl.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.constants.common.ExternalServiceType;
@@ -60,7 +60,7 @@ import org.opendatakit.common.web.CallingContext;
  */
 public class WatchdogWorkerImpl {
 
-  private Log logger = LogFactory.getLog(WatchdogWorkerImpl.class);
+  private Logger logger = LoggerFactory.getLogger(WatchdogWorkerImpl.class);
 
   private static class SubmissionMetadata {
     public final String uri;

--- a/src/main/java/org/opendatakit/aggregate/task/WorksheetCreatorWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/WorksheetCreatorWorkerImpl.java
@@ -19,8 +19,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.constants.TaskLockType;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
@@ -49,6 +49,7 @@ import org.opendatakit.common.web.CallingContext;
  *
  */
 public class WorksheetCreatorWorkerImpl {
+    private static final Logger logger = LoggerFactory.getLogger(WorksheetCreatorWorkerImpl.class);
 
     private final IForm form;
     private final SubmissionKey miscTasksKey;
@@ -96,7 +97,7 @@ public class WorksheetCreatorWorkerImpl {
 
     public final void worksheetCreator() {
 
-     Log logger = LogFactory.getLog(WorksheetCreatorWorkerImpl.class);
+     Logger logger = LoggerFactory.getLogger(WorksheetCreatorWorkerImpl.class);
      logger.info("Beginning Worksheet Creator: " + miscTasksKey.toString() +
                    " form " + form.getFormId());
 
@@ -139,7 +140,7 @@ public class WorksheetCreatorWorkerImpl {
               doMarkAsComplete(t);
           } else {
               // worksheet creation request should have been created after the form...
-              doWorksheetCreator(logger);
+              doWorksheetCreator();
           }
         } catch (Exception e2) {
           // some other unexpected exception...
@@ -173,7 +174,7 @@ public class WorksheetCreatorWorkerImpl {
         t.persist(cc);
     }
 
-    public final void doWorksheetCreator(Log logger) {
+    public final void doWorksheetCreator() {
       try {
         // get spreadsheet
         GoogleSpreadsheet spreadsheet = getGoogleSpreadsheetWithName();
@@ -229,7 +230,7 @@ public class WorksheetCreatorWorkerImpl {
             r.persist(cc);
         }
     } catch (Exception ex) {
-     Log logger = LogFactory.getLog(WorksheetCreatorWorkerImpl.class);
+     Logger logger = LoggerFactory.getLogger(WorksheetCreatorWorkerImpl.class);
      logger.error("failureRecovery: " + miscTasksKey.toString() +
          " form " + form.getFormId() + " Exception during failure recovery: " + ex.toString());
         // something is hosed -- don't attempt to continue.

--- a/src/main/java/org/opendatakit/aggregate/task/gae/WatchdogImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/WatchdogImpl.java
@@ -20,8 +20,8 @@ import java.net.UnknownHostException;
 
 import javax.servlet.ServletContext;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.aggregate.task.CsvGenerator;
@@ -56,7 +56,7 @@ import org.springframework.beans.factory.InitializingBean;
  */
 public class WatchdogImpl implements Watchdog, InitializingBean {
 
-  private Log logger = LogFactory.getLog(WatchdogImpl.class);
+  private Logger logger = LoggerFactory.getLogger(WatchdogImpl.class);
 
   /** cached value of the faster-watchdog-cycle flag */
   private boolean lastFasterWatchdogCycleEnabledFlag = false;

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/CsvGeneratorTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/CsvGeneratorTaskServlet.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.exception.ODKFormNotFoundException;
@@ -46,7 +46,7 @@ public class CsvGeneratorTaskServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = 5552217246831515463L;
 
-  private static final Log logger = LogFactory.getLog(CsvGeneratorTaskServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(CsvGeneratorTaskServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/FormDeleteTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/FormDeleteTaskServlet.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.exception.ODKExternalServiceDependencyException;
@@ -49,7 +49,7 @@ public class FormDeleteTaskServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = 8219849865201422548L;
 
-  private static final Log logger = LogFactory.getLog(FormDeleteTaskServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(FormDeleteTaskServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/JsonGeneratorTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/JsonGeneratorTaskServlet.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.exception.ODKFormNotFoundException;
@@ -26,7 +26,7 @@ public class JsonGeneratorTaskServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = -2571463127331034693L;
 
-  private static final Log logger = LogFactory.getLog(JsonGeneratorTaskServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(JsonGeneratorTaskServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/KmlGeneratorTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/KmlGeneratorTaskServlet.java
@@ -22,8 +22,8 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.form.KmlSelection;
 import org.opendatakit.aggregate.constants.ServletConsts;
@@ -50,7 +50,7 @@ public class KmlGeneratorTaskServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = 8647919526257827291L;
 
-  private static final Log logger = LogFactory.getLog(KmlGeneratorTaskServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(KmlGeneratorTaskServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/PurgeOlderSubmissionsTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/PurgeOlderSubmissionsTaskServlet.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.exception.ODKExternalServiceDependencyException;
@@ -51,7 +51,7 @@ public class PurgeOlderSubmissionsTaskServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = 8219849865201422548L;
 
-  private static final Log logger = LogFactory.getLog(PurgeOlderSubmissionsTaskServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(PurgeOlderSubmissionsTaskServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/UploadSubmissionsTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/UploadSubmissionsTaskServlet.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.externalservice.ExternalServiceConsts;
@@ -50,7 +50,7 @@ public class UploadSubmissionsTaskServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = 4295412985320942608L;
 
-  private static final Log logger = LogFactory.getLog(UploadSubmissionsTaskServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(UploadSubmissionsTaskServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/UploadSubmissionsTaskServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/UploadSubmissionsTaskServlet.java
@@ -15,18 +15,15 @@
  */
 package org.opendatakit.aggregate.task.gae.servlet;
 
+import com.google.appengine.api.modules.ModulesService;
+import com.google.appengine.api.modules.ModulesServiceFactory;
 import java.io.IOException;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.externalservice.ExternalServiceConsts;
 import org.opendatakit.aggregate.exception.ODKExternalServiceException;
-import org.opendatakit.aggregate.exception.ODKFormNotFoundException;
 import org.opendatakit.aggregate.externalservice.FormServiceCursor;
 import org.opendatakit.aggregate.servlet.ServletUtilBase;
 import org.opendatakit.aggregate.task.UploadSubmissionsWorkerImpl;
@@ -34,15 +31,12 @@ import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.persistence.exception.ODKEntityNotFoundException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
 import org.opendatakit.common.web.CallingContext;
-
-import com.google.appengine.api.modules.ModulesService;
-import com.google.appengine.api.modules.ModulesServiceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- *
  * @author wbrunette@gmail.com
  * @author mitchellsundt@gmail.com
- *
  */
 public class UploadSubmissionsTaskServlet extends ServletUtilBase {
   /**
@@ -61,7 +55,7 @@ public class UploadSubmissionsTaskServlet extends ServletUtilBase {
    * Handler for HTTP Get request to create xform upload page
    *
    * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
-   *      javax.servlet.http.HttpServletResponse)
+   *     javax.servlet.http.HttpServletResponse)
    */
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -81,20 +75,12 @@ public class UploadSubmissionsTaskServlet extends ServletUtilBase {
     try {
       fsc = FormServiceCursor.getFormServiceCursor(fscUri, cc);
     } catch (ODKEntityNotFoundException e) {
-      // TODO: fix bug we should not be generating tasks for fsc that don't
-      // exist
-      // however not critical bug as execution path dies with this try/catch
-      logger.error("BUG: we generated an task for a form service cursor that didn't exist"
-          + e.toString());
-      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.toString());
-      return;
-    } catch (ODKOverQuotaException e) {
-      logger.error("Over quota." + e.toString());
+      // TODO: fix bug we should not be generating tasks for fsc that don't exist however not critical bug as execution path dies with this try/catch
+      logger.error("BUG: we generated an task for a form service cursor that didn't exist", e);
       resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.toString());
       return;
     } catch (ODKDatastoreException e) {
-      e.printStackTrace();
-      logger.error("Datastore failure." + e.toString());
+      logger.error("Upload submission error", e);
       resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.toString());
       return;
     }
@@ -109,24 +95,9 @@ public class UploadSubmissionsTaskServlet extends ServletUtilBase {
       worker.uploadAllSubmissions();
       logger.info("ending successful servlet processing");
       resp.setStatus(HttpServletResponse.SC_ACCEPTED);
-    } catch (ODKEntityNotFoundException e) {
-      e.printStackTrace();
-      logger.error(e.toString());
-      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.toString());
-      return;
-    } catch (ODKExternalServiceException e) {
-      logger.error(e.toString());
-      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.toString());
-      return;
-    } catch (ODKFormNotFoundException e) {
-      logger.error(e.toString());
-      odkIdNotFoundError(resp);
-      return;
     } catch (Exception e) {
-      e.printStackTrace();
-      logger.error(e.toString());
+      logger.error("Upload submission error", e);
       resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.toString());
-      return;
     }
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/WatchdogServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/WatchdogServlet.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.exception.ODKExternalServiceException;
 import org.opendatakit.aggregate.exception.ODKFormNotFoundException;
@@ -43,7 +43,7 @@ public class WatchdogServlet extends ServletUtilBase{
    */
   private static final long serialVersionUID = 4295412985320942609L;
 
-  private static final Log logger = LogFactory.getLog(WatchdogServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(WatchdogServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/gae/servlet/WorksheetServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/task/gae/servlet/WorksheetServlet.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
@@ -51,7 +51,7 @@ public class WorksheetServlet extends ServletUtilBase {
    */
   private static final long serialVersionUID = 3054003683995535651L;
 
-  private static final Log logger = LogFactory.getLog(WorksheetServlet.class);
+  private static final Logger logger = LoggerFactory.getLogger(WorksheetServlet.class);
 
   /**
    * URI from base

--- a/src/main/java/org/opendatakit/aggregate/task/tomcat/WatchdogImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/tomcat/WatchdogImpl.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ScheduledFuture;
 
 import javax.servlet.ServletContext;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.aggregate.task.CsvGenerator;
@@ -61,7 +61,7 @@ import org.springframework.web.context.ServletContextAware;
 public class WatchdogImpl implements Watchdog, SmartLifecycle, InitializingBean,
     ServletContextAware {
 
-  private Log logger = LogFactory.getLog(WatchdogImpl.class);
+  private Logger logger = LoggerFactory.getLogger(WatchdogImpl.class);
 
   /** cached value of the faster-watchdog-cycle flag */
   private boolean lastFasterWatchdogCycleEnabledFlag = false;

--- a/src/main/java/org/opendatakit/aggregate/util/BackendActionsTable.java
+++ b/src/main/java/org/opendatakit/aggregate/util/BackendActionsTable.java
@@ -19,8 +19,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.aggregate.task.Watchdog;
@@ -63,7 +63,7 @@ public class BackendActionsTable extends CommonFieldsBase {
   private static final DataField LAST_REVISION_DATE = new DataField("LAST_REVISION",
       DataField.DataType.DATETIME, true);
 
-  private static final Log logger = LogFactory.getLog(BackendActionsTable.class);
+  private static final Logger logger = LoggerFactory.getLogger(BackendActionsTable.class);
 
   /** delay between re-loads of the lastPublisherRevision HashMap. 30 seconds. */
   public static final long HASHMAP_LIFETIME_MILLISECONDS = PersistConsts.MAX_SETTLE_MILLISECONDS * 10L;

--- a/src/main/java/org/opendatakit/common/datamodel/DeleteHelper.java
+++ b/src/main/java/org/opendatakit/common/datamodel/DeleteHelper.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.datamodel.TopLevelDynamicBase;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.EntityKey;
@@ -33,6 +33,9 @@ import org.opendatakit.common.persistence.exception.ODKEntityNotFoundException;
 import org.opendatakit.common.web.CallingContext;
 
 public class DeleteHelper {
+
+  public static final Logger logger = LoggerFactory
+      .getLogger(DeleteHelper.class);
 
   private DeleteHelper() {
   }
@@ -57,10 +60,7 @@ public class DeleteHelper {
       // try to do it the fast way...
       cc.getDatastore().deleteEntities(keys, cc.getCurrentUser());
     } catch (Exception e) {
-      LogFactory
-          .getLog(DeleteHelper.class)
-          .warn(
-              "Datastore failure while performing straight-forward delete of entities - attempting them individually");
+      logger.warn("Datastore failure while performing straight-forward delete of entities - attempting them individually");
       // we have a failure. Go through, deleting each in turn. If
       // the object does not exist, ignore the error. Otherwise,
       // abort at the first error found. This ensures that we are
@@ -98,14 +98,14 @@ public class DeleteHelper {
           // ignore this... if we are retrying we expect these...
         } catch (ODKDatastoreException ex) {
           // and log this... these are things to clean up manually...
-          LogFactory.getLog(DeleteHelper.class).warn(
+          LoggerFactory.getLogger(DeleteHelper.class).warn(
               "Datastore failure while deleting " + key.getRelation().getSchemaName() + "."
                   + key.getRelation().getTableName() + " " + CommonFieldsBase.URI_COLUMN_NAME
                   + " = " + key.getKey());
           ex.printStackTrace();
           throw ex;
         } catch (Exception ex) {
-          LogFactory.getLog(DeleteHelper.class).warn(
+          LoggerFactory.getLogger(DeleteHelper.class).warn(
               "Unexpected exception while deleting " + key.getRelation().getSchemaName() + "."
                   + key.getRelation().getTableName() + " " + CommonFieldsBase.URI_COLUMN_NAME
                   + " = " + key.getKey());
@@ -119,7 +119,7 @@ public class DeleteHelper {
   public static void deleteDamagedSubmission(TopLevelDynamicBase tle,
       Set<DynamicCommonFieldsBase> backingObjects, CallingContext cc) throws ODKDatastoreException {
     
-    Log logger = LogFactory.getLog(DeleteHelper.class);
+    Logger logger = LoggerFactory.getLogger(DeleteHelper.class);
 
     Set<DynamicDocumentBase> documents = new TreeSet<DynamicDocumentBase>(
         DynamicCommonFieldsBase.sameTableName);

--- a/src/main/java/org/opendatakit/common/persistence/engine/DatastoreAccessMetrics.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/DatastoreAccessMetrics.java
@@ -16,8 +16,8 @@ package org.opendatakit.common.persistence.engine;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.EntityKey;
 import org.opendatakit.common.utils.WebUtils;
@@ -35,7 +35,7 @@ import org.opendatakit.common.utils.WebUtils;
  */
 public final class DatastoreAccessMetrics {
 
-  private static final Log logger = LogFactory.getLog(DatastoreAccessMetrics.class);
+  private static final Logger logger = LoggerFactory.getLogger(DatastoreAccessMetrics.class);
 
   // map of fully qualified table name to index in counter array.
   private final Map<String, Short> tableMap = new TreeMap<String, Short>();

--- a/src/main/java/org/opendatakit/common/persistence/engine/gae/DatastoreImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/gae/DatastoreImpl.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.Datastore;
@@ -81,7 +81,7 @@ public class DatastoreImpl implements Datastore {
     ds = DatastoreServiceFactory.getDatastoreService();
     schemaName = "opendatakit";
     
-    LogFactory.getLog(DatastoreImpl.class).info("Running on " + 
+    LoggerFactory.getLogger(DatastoreImpl.class).info("Running on " + 
           ds.getDatastoreAttributes().getDatastoreType().toString() + " datastore");
     
     try {
@@ -89,7 +89,7 @@ public class DatastoreImpl implements Datastore {
     } catch (Throwable t) {
       // if we can't get a syncCache, that is OK
       syncCache = null;
-      LogFactory.getLog(DatastoreImpl.class).info("MemcacheService could not be created");
+      LoggerFactory.getLogger(DatastoreImpl.class).info("MemcacheService could not be created");
     }
   }
 
@@ -442,7 +442,7 @@ public class DatastoreImpl implements Datastore {
     Key dsKey = constructGaeKey(key.getRelation(), key.getKey());
     dam.recordDeleteUsage(key);
     try {
-      LogFactory.getLog(DatastoreImpl.class).info(
+      LoggerFactory.getLogger(DatastoreImpl.class).info(
           "Executing delete " + constructGaeKind(key.getRelation()) + " with key " + key.getKey()
               + " by user " + user.getUriUser());
       ds.delete(dsKey);
@@ -464,7 +464,7 @@ public class DatastoreImpl implements Datastore {
     for (EntityKey entityKey : keys) {
       dam.recordDeleteUsage(entityKey);
       datastoreKeys.add(constructGaeKey(entityKey.getRelation(), entityKey.getKey()));
-      LogFactory.getLog(DatastoreImpl.class).info(
+      LoggerFactory.getLogger(DatastoreImpl.class).info(
           "Executing delete " + constructGaeKind(entityKey.getRelation()) + " with key "
               + entityKey.getKey() + " by user " + user.getUriUser());
     }

--- a/src/main/java/org/opendatakit/common/persistence/engine/gae/ExecutionTimeLogger.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/gae/ExecutionTimeLogger.java
@@ -13,8 +13,8 @@
  */
 package org.opendatakit.common.persistence.engine.gae;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 
 /**
@@ -29,16 +29,16 @@ final class ExecutionTimeLogger {
   private final String loggingContextTag;
   private final CommonFieldsBase relation;
   private final long startApiTime;
-  private final Log logger;
-  private final Log queryStringLogger;
+  private final Logger logger;
+  private final Logger queryStringLogger;
   private long istartApiTime;
   String queryString = null;
 
   ExecutionTimeLogger(DatastoreImpl datastore, String loggingContextTag, CommonFieldsBase relation) {
     this.loggingContextTag = loggingContextTag;
     this.relation = relation;
-    this.logger = LogFactory.getLog(ExecutionTimeLogger.class);
-    this.queryStringLogger = LogFactory.getLog("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
+    this.logger = LoggerFactory.getLogger(ExecutionTimeLogger.class);
+    this.queryStringLogger = LoggerFactory.getLogger("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
     QueryImpl.updateCostLoggingThreshold(datastore);
 
     istartApiTime = startApiTime = System.currentTimeMillis();

--- a/src/main/java/org/opendatakit/common/persistence/engine/gae/QueryImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/gae/QueryImpl.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.DataField.DataType;
@@ -74,7 +74,7 @@ public class QueryImpl implements org.opendatakit.common.persistence.Query {
   private final CommonFieldsBase relation;
   private final DatastoreImpl datastore;
   private final User user;
-  private final Log logger;
+  private final Logger logger;
   private final ExecutionTimeLogger gaeCostLogger;
 
   private static final long ACTIVE_COST_LOGGING_CHECK_INTERVAL = 10 * 1000; // 10
@@ -84,7 +84,7 @@ public class QueryImpl implements org.opendatakit.common.persistence.Query {
   private static long milliLastCheck = 0L;
 
   final static synchronized void updateCostLoggingThreshold(DatastoreImpl datastore) {
-    Log logger = LogFactory.getLog(QueryImpl.class);
+    Logger logger = LoggerFactory.getLogger(QueryImpl.class);
 
     long currentTime = System.currentTimeMillis();
     if (milliLastCheck + ACTIVE_COST_LOGGING_CHECK_INTERVAL < currentTime) {
@@ -174,7 +174,7 @@ public class QueryImpl implements org.opendatakit.common.persistence.Query {
     this.loggingContextTag = loggingContextTag;
     this.datastore = datastore;
     this.user = user;
-    this.logger = LogFactory.getLog(QueryImpl.class);
+    this.logger = LoggerFactory.getLogger(QueryImpl.class);
     this.gaeCostLogger = new ExecutionTimeLogger(datastore, loggingContextTag, relation);
   }
 

--- a/src/main/java/org/opendatakit/common/persistence/engine/gae/StringFieldLengthMapping.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/gae/StringFieldLengthMapping.java
@@ -16,8 +16,8 @@ package org.opendatakit.common.persistence.engine.gae;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.DataField.DataType;
@@ -50,7 +50,7 @@ public class StringFieldLengthMapping {
   private static final String TABLE_NAME = "_STRING_FIELD_LENGTHS_";
   private static final String LENGTH_MAPPING = "LENGTH_MAPPING";
 
-  private Log logger = LogFactory.getLog(StringFieldLengthMapping.class);
+  private Logger logger = LoggerFactory.getLogger(StringFieldLengthMapping.class);
   
   public StringFieldLengthMapping() {
   }

--- a/src/main/java/org/opendatakit/common/persistence/engine/gae/TaskLockImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/gae/TaskLockImpl.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.ITaskLockType;
 import org.opendatakit.common.persistence.TaskLock;
 import org.opendatakit.common.persistence.engine.DatastoreAccessMetrics;
@@ -72,13 +72,13 @@ public class TaskLockImpl implements TaskLock {
   private final DatastoreAccessMetrics dam;
   private final MemcacheService syncCache;
   private final DatastoreService ds;
-  private final Log log;
+  private final Logger log;
 
   public TaskLockImpl(DatastoreAccessMetrics dam, MemcacheService syncCache) {
     this.dam = dam;
     this.syncCache = syncCache;
     ds = DatastoreServiceFactory.getDatastoreService();
-    log = LogFactory.getLog(TaskLockImpl.class);
+    log = LoggerFactory.getLogger(TaskLockImpl.class);
   }
 
   /**

--- a/src/main/java/org/opendatakit/common/persistence/engine/mysql/DatastoreImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/mysql/DatastoreImpl.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.DataField.IndexType;
@@ -83,13 +83,13 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       Class.forName("com.mysql.jdbc.Driver");
     } catch ( Exception e ) {
       // ignore this but log a brief info message
-      LogFactory.getLog(DatastoreImpl.class).info("Failed to load com.mysql.jdbc.Driver (did you download and install/copy MySQL Connector/J ?) Exception: " + e.toString());
+      LoggerFactory.getLogger(DatastoreImpl.class).info("Failed to load com.mysql.jdbc.Driver (did you download and install/copy MySQL Connector/J ?) Exception: " + e.toString());
     }
     try {
       Class.forName("com.mysql.jdbc.GoogleDriver");
     } catch ( Exception e ) {
       // ignore this but log a brief info message
-      LogFactory.getLog(DatastoreImpl.class).info("Failed to load com.mysql.jdbc.GoogleDriver Exception: " + e.toString());
+      LoggerFactory.getLogger(DatastoreImpl.class).info("Failed to load com.mysql.jdbc.GoogleDriver Exception: " + e.toString());
     }
     this.tm = new DataSourceTransactionManager(dataSource);
   }
@@ -733,9 +733,9 @@ public class DatastoreImpl implements Datastore, InitializingBean {
         b.append(K_CLOSE_PAREN);
 
         String createTableStmt = b.toString();
-        LogFactory.getLog(DatastoreImpl.class).info("Attempting: " + createTableStmt);
+        LoggerFactory.getLogger(DatastoreImpl.class).info("Attempting: " + createTableStmt);
         jc.execute(createTableStmt);
-        LogFactory.getLog(DatastoreImpl.class)
+        LoggerFactory.getLogger(DatastoreImpl.class)
             .info("create table success (before updateRelation): " + relation.getTableName());
 
         // and update the relation with actual dimensions...
@@ -746,7 +746,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       if (status != null) {
         tm.rollback(status);
       }
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .warn("Failure: " + relation.getTableName() + " exception: " + e.toString());
       throw new ODKDatastoreException(e);
     }
@@ -773,10 +773,10 @@ public class DatastoreImpl implements Datastore, InitializingBean {
     } catch (BadSqlGrammarException e) {
       dam.recordQueryUsage("SHOW CREATE TABLE", 0);
       // we expect this if the table does not exist...
-      LogFactory.getLog(DatastoreImpl.class).info(tableName + " does not exist!");
+      LoggerFactory.getLogger(DatastoreImpl.class).info(tableName + " does not exist!");
       return false;
     }
-    LogFactory.getLog(DatastoreImpl.class).info(tableName + " exists!");
+    LoggerFactory.getLogger(DatastoreImpl.class).info(tableName + " exists!");
     return true;
   }
 
@@ -793,11 +793,11 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       b.append(relation.getTableName());
       b.append(K_BQ);
 
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .info("Executing " + b.toString() + " by user " + user.getUriUser());
       getJdbcConnection().execute(b.toString());
     } catch (Exception e) {
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .warn(relation.getTableName() + " exception: " + e.toString());
       throw new ODKDatastoreException(e);
     }
@@ -910,7 +910,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
           SqlParameterValue arg = argList.get(i);
           createLogContent(b, i+1, arg);
         }
-        LogFactory.getLog(DatastoreImpl.class).info(b.toString());
+        LoggerFactory.getLogger(DatastoreImpl.class).info(b.toString());
       }
       for (int i = 0; i < argList.size(); ++i) {
         SqlParameterValue arg = argList.get(i);
@@ -1251,7 +1251,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       b.append(K_EQ);
       b.append(K_BIND_VALUE);
 
-      LogFactory.getLog(DatastoreImpl.class).info("Executing " + b.toString() + " with key "
+      LoggerFactory.getLogger(DatastoreImpl.class).info("Executing " + b.toString() + " with key "
           + key.getKey() + " by user " + user.getUriUser());
       getJdbcConnection().update(b.toString(), new Object[] { key.getKey() });
     } catch (Exception e) {

--- a/src/main/java/org/opendatakit/common/persistence/engine/mysql/QueryImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/mysql/QueryImpl.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.EntityKey;
@@ -85,11 +85,11 @@ public class QueryImpl implements Query {
   private final StringBuilder queryBindBuilder = new StringBuilder();
   private final List<Object> bindValues = new ArrayList<Object>();
   private final StringBuilder querySortBuilder = new StringBuilder();
-  private final Log queryStringLogger;
+  private final Logger queryStringLogger;
 
   public QueryImpl(CommonFieldsBase relation, String loggingContextTag,
       DatastoreImpl dataStoreImpl, User user) {
-    this.queryStringLogger = LogFactory.getLog("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
+    this.queryStringLogger = LoggerFactory.getLogger("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
     this.relation = relation;
     this.dataStoreImpl = dataStoreImpl;
     this.user = user;

--- a/src/main/java/org/opendatakit/common/persistence/engine/mysql/TaskLockImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/mysql/TaskLockImpl.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.Datastore;
@@ -358,7 +358,7 @@ public class TaskLockImpl implements TaskLock {
           } finally {
             if ( !success ) {
               Statement stmt = conn.createStatement();
-              LogFactory.getLog(TaskLockImpl.class).info("UNLOCK TABLES");
+              LoggerFactory.getLogger(TaskLockImpl.class).info("UNLOCK TABLES");
               stmt.execute("UNLOCK TABLES");
               conn.commit();
             }
@@ -442,7 +442,7 @@ public class TaskLockImpl implements TaskLock {
       result = true;
     } catch (ODKDatastoreException e) {
       // if we see a lot of these, we are running too long between renewals
-      LogFactory.getLog(TaskLockImpl.class).info("delete of taskLock threw exception!");
+      LoggerFactory.getLogger(TaskLockImpl.class).info("delete of taskLock threw exception!");
       e.printStackTrace();
     }
     return result;

--- a/src/main/java/org/opendatakit/common/persistence/engine/pgres/DatastoreImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/pgres/DatastoreImpl.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.DataField.IndexType;
@@ -624,10 +624,10 @@ public class DatastoreImpl implements Datastore, InitializingBean {
         }
 
         String createTableStmt = b.toString();
-        LogFactory.getLog(DatastoreImpl.class).info("Attempting: " + createTableStmt);
+        LoggerFactory.getLogger(DatastoreImpl.class).info("Attempting: " + createTableStmt);
 
         jc.execute(createTableStmt);
-        LogFactory.getLog(DatastoreImpl.class)
+        LoggerFactory.getLogger(DatastoreImpl.class)
             .info("create table success (before updateRelation): " + relation.getTableName());
 
         String idx;
@@ -720,11 +720,11 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       b.append(relation.getTableName());
       b.append(K_BQ);
 
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .info("Executing " + b.toString() + " by user " + user.getUriUser());
       getJdbcConnection().execute(b.toString());
     } catch (Exception e) {
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .warn(relation.getTableName() + " exception: " + e.toString());
       throw new ODKDatastoreException(e);
     }
@@ -837,7 +837,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
           SqlParameterValue arg = argList.get(i);
           createLogContent(b, i+1, arg);
         }
-        LogFactory.getLog(DatastoreImpl.class).info(b.toString());
+        LoggerFactory.getLogger(DatastoreImpl.class).info(b.toString());
       }
       for (int i = 0; i < argList.size(); ++i) {
         SqlParameterValue arg = argList.get(i);
@@ -1178,7 +1178,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       b.append(K_EQ);
       b.append(K_BIND_VALUE);
 
-      LogFactory.getLog(DatastoreImpl.class).info("Executing " + b.toString() + " with key "
+      LoggerFactory.getLogger(DatastoreImpl.class).info("Executing " + b.toString() + " with key "
           + key.getKey() + " by user " + user.getUriUser());
       getJdbcConnection().update(b.toString(), new Object[] { key.getKey() });
     } catch (Exception e) {

--- a/src/main/java/org/opendatakit/common/persistence/engine/pgres/QueryImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/pgres/QueryImpl.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.EntityKey;
@@ -85,11 +85,11 @@ public class QueryImpl implements Query {
   private final StringBuilder queryBindBuilder = new StringBuilder();
   private final List<Object> bindValues = new ArrayList<Object>();
   private final StringBuilder querySortBuilder = new StringBuilder();
-  private final Log queryStringLogger;
+  private final Logger queryStringLogger;
 
   public QueryImpl(CommonFieldsBase relation, String loggingContextTag,
       DatastoreImpl dataStoreImpl, User user) {
-    this.queryStringLogger = LogFactory.getLog("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
+    this.queryStringLogger = LoggerFactory.getLogger("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
     this.relation = relation;
     this.dataStoreImpl = dataStoreImpl;
     this.user = user;

--- a/src/main/java/org/opendatakit/common/persistence/engine/pgres/TaskLockImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/pgres/TaskLockImpl.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.Datastore;
@@ -237,7 +237,7 @@ public class TaskLockImpl implements TaskLock {
             conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
             Statement stmt = conn.createStatement();
             for (String s : stmts) {
-              // for debugging: LogFactory.getLog(TaskLockImpl.class).info(s);
+              // for debugging: LoggerFactory.getLogger(TaskLockImpl.class).info(s);
               stmt.execute(s);
             }
             conn.commit();
@@ -320,7 +320,7 @@ public class TaskLockImpl implements TaskLock {
       result = true;
     } catch (ODKDatastoreException e) {
       // if we see a lot of these, we are running too long between renewals
-      LogFactory.getLog(TaskLockImpl.class).info("delete of taskLock threw exception!");
+      LoggerFactory.getLogger(TaskLockImpl.class).info("delete of taskLock threw exception!");
       e.printStackTrace();
     }
     return result;

--- a/src/main/java/org/opendatakit/common/persistence/engine/sqlserver/DatastoreImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/sqlserver/DatastoreImpl.java
@@ -28,7 +28,7 @@ import java.util.TimeZone;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.DataField.DataType;
@@ -686,10 +686,10 @@ public class DatastoreImpl implements Datastore, InitializingBean {
         }
         
         String createTableStmt = b.toString();
-        LogFactory.getLog(DatastoreImpl.class).info("Attempting: " + createTableStmt);
+        LoggerFactory.getLogger(DatastoreImpl.class).info("Attempting: " + createTableStmt);
 
         jc.execute(createTableStmt);
-        LogFactory.getLog(DatastoreImpl.class)
+        LoggerFactory.getLogger(DatastoreImpl.class)
             .info("create table success (before updateRelation): " + relation.getTableName());
 
         boolean alreadyClustered = false;
@@ -792,11 +792,11 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       b.append(relation.getTableName());
       b.append(K_BQ);
 
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .info("Executing " + b.toString() + " by user " + user.getUriUser());
       getJdbcConnection().execute(b.toString());
     } catch (Exception e) {
-      LogFactory.getLog(DatastoreImpl.class)
+      LoggerFactory.getLogger(DatastoreImpl.class)
           .warn(relation.getTableName() + " exception: " + e.toString());
       throw new ODKDatastoreException(e);
     }
@@ -909,7 +909,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
           SqlParameterValue arg = argList.get(i);
           createLogContent(b, i+1, arg);
         }
-        LogFactory.getLog(DatastoreImpl.class).info(b.toString());
+        LoggerFactory.getLogger(DatastoreImpl.class).info(b.toString());
       }
       for (int i = 0; i < argList.size(); ++i) {
         SqlParameterValue arg = argList.get(i);
@@ -1266,7 +1266,7 @@ public class DatastoreImpl implements Datastore, InitializingBean {
       b.append(K_EQ);
       b.append(K_BIND_VALUE);
 
-      LogFactory.getLog(DatastoreImpl.class).info("Executing " + b.toString() + " with key "
+      LoggerFactory.getLogger(DatastoreImpl.class).info("Executing " + b.toString() + " with key "
           + key.getKey() + " by user " + user.getUriUser());
       getJdbcConnection().update(b.toString(), new Object[] { key.getKey() });
     } catch (Exception e) {

--- a/src/main/java/org/opendatakit/common/persistence/engine/sqlserver/QueryImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/sqlserver/QueryImpl.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.EntityKey;
@@ -85,11 +85,11 @@ public class QueryImpl implements Query {
   private final StringBuilder queryBindBuilder = new StringBuilder();
   private final List<Object> bindValues = new ArrayList<Object>();
   private final StringBuilder querySortBuilder = new StringBuilder();
-  private final Log queryStringLogger;
+  private final Logger queryStringLogger;
 
   public QueryImpl(CommonFieldsBase relation, String loggingContextTag,
       DatastoreImpl dataStoreImpl, User user) {
-    this.queryStringLogger = LogFactory.getLog("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
+    this.queryStringLogger = LoggerFactory.getLogger("org.opendatakit.common.persistence.LogQueryString." + relation.getSchemaName() + "." + relation.getTableName());
     this.relation = relation;
     this.dataStoreImpl = dataStoreImpl;
     this.user = user;

--- a/src/main/java/org/opendatakit/common/persistence/engine/sqlserver/TaskLockImpl.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/sqlserver/TaskLockImpl.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
 import org.opendatakit.common.persistence.Datastore;
@@ -235,7 +235,7 @@ public class TaskLockImpl implements TaskLock {
             conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
             Statement stmt = conn.createStatement();
             for (String s : stmts) {
-              // for debugging: LogFactory.getLog(TaskLockImpl.class).info(s);
+              // for debugging: LoggerFactory.getLogger(TaskLockImpl.class).info(s);
               stmt.execute(s);
             }
             conn.commit();
@@ -318,7 +318,7 @@ public class TaskLockImpl implements TaskLock {
       result = true;
     } catch (ODKDatastoreException e) {
       // if we see a lot of these, we are running too long between renewals
-      LogFactory.getLog(TaskLockImpl.class).info("delete of taskLock threw exception!");
+      LoggerFactory.getLogger(TaskLockImpl.class).info("delete of taskLock threw exception!");
       e.printStackTrace();
     }
     return result;

--- a/src/main/java/org/opendatakit/common/security/Realm.java
+++ b/src/main/java/org/opendatakit/common/security/Realm.java
@@ -15,8 +15,8 @@
  */
 package org.opendatakit.common.security;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.springframework.beans.factory.InitializingBean;
 
@@ -47,7 +47,7 @@ public class Realm implements InitializingBean {
         if ( realmString == null ) {
             throw new IllegalStateException("realmString (e.g., mydomain.org ODK Aggregate 1.0) must be specified");
         }
-        Log log = LogFactory.getLog(Realm.class);
+        Logger log = LoggerFactory.getLogger(Realm.class);
         log.info("Version: " + UIConsts.VERSION_STRING);
         log.info("Hostname: " + hostname);
         log.info("Port: " + Integer.toString(port));

--- a/src/main/java/org/opendatakit/common/security/spring/GWTAccessDeniedHandlerImpl.java
+++ b/src/main/java/org/opendatakit/common/security/spring/GWTAccessDeniedHandlerImpl.java
@@ -23,7 +23,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -93,7 +93,7 @@ public class GWTAccessDeniedHandlerImpl implements AccessDeniedHandler, ServletC
                 RPCRequest rpcRequest = RPC.decodeRequest(payload);
                 onAfterRequestDeserialized(rpcRequest);
                 // ******* CHANGED GWT 2.4 CODE STARTS
-                LogFactory.getLog(GWTAccessDeniedHandlerImpl.class).warn("GWT Method: " 
+                LoggerFactory.getLogger(GWTAccessDeniedHandlerImpl.class).warn("GWT Method: " 
                             + rpcRequest.getMethod().getName() + " Exception: " + e.getMessage());
                 return RPC
                         .encodeResponseForFailure(
@@ -102,7 +102,7 @@ public class GWTAccessDeniedHandlerImpl implements AccessDeniedHandler, ServletC
                                         e));
                 // ******** CHANGED GWT 2.4 CODE ENDS
             } catch (IncompatibleRemoteServiceException ex) {
-                LogFactory.getLog(GWTAccessDeniedHandlerImpl.class).warn("An IncompatibleRemoteServiceException was thrown while processing this call.",
+                LoggerFactory.getLogger(GWTAccessDeniedHandlerImpl.class).warn("An IncompatibleRemoteServiceException was thrown while processing this call.",
                         ex);
                 return RPC.encodeResponseForFailure(null, ex);
             }

--- a/src/main/java/org/opendatakit/common/security/spring/Oauth2AuthenticationProvider.java
+++ b/src/main/java/org/opendatakit/common/security/spring/Oauth2AuthenticationProvider.java
@@ -20,8 +20,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.security.SecurityUtils;
 import org.opendatakit.common.security.common.GrantedAuthorityName;
 import org.springframework.beans.factory.InitializingBean;
@@ -44,7 +44,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
  */
 public class Oauth2AuthenticationProvider implements AuthenticationProvider, InitializingBean {
 
-  private static final Log logger = LogFactory.getLog(Oauth2AuthenticationProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(Oauth2AuthenticationProvider.class);
 
   //~ Instance fields ================================================================================================
 

--- a/src/main/java/org/opendatakit/common/security/spring/Oauth2ResourceFilter.java
+++ b/src/main/java/org/opendatakit/common/security/spring/Oauth2ResourceFilter.java
@@ -35,8 +35,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -82,7 +82,7 @@ public class Oauth2ResourceFilter extends GenericFilterBean {
   private static final String ACCESS_TOKEN = "access_token";
   private static final String BEARER_TYPE = "Bearer";
 
-  private Log logger = LogFactory.getLog(Oauth2ResourceFilter.class);
+  private Logger logger = LoggerFactory.getLogger(Oauth2ResourceFilter.class);
   private static final ObjectMapper mapper = new ObjectMapper();
 
   private AuthenticationProvider authenticationProvider = null;

--- a/src/main/java/org/opendatakit/common/security/spring/OutOfBandAuthenticationProvider.java
+++ b/src/main/java/org/opendatakit/common/security/spring/OutOfBandAuthenticationProvider.java
@@ -20,8 +20,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.security.SecurityUtils;
 import org.opendatakit.common.security.common.GrantedAuthorityName;
 import org.springframework.beans.factory.InitializingBean;
@@ -44,7 +44,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
  */
 public class OutOfBandAuthenticationProvider implements AuthenticationProvider, InitializingBean {
 
-  private static final Log logger = LogFactory.getLog(OutOfBandAuthenticationProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(OutOfBandAuthenticationProvider.class);
 
   //~ Instance fields ================================================================================================
 

--- a/src/main/java/org/opendatakit/common/security/spring/OutOfBandUserFilter.java
+++ b/src/main/java/org/opendatakit/common/security/spring/OutOfBandUserFilter.java
@@ -24,8 +24,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.utils.OutOfBandUserFetcher;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
@@ -50,7 +50,7 @@ import org.springframework.web.filter.GenericFilterBean;
  */
 public class OutOfBandUserFilter extends GenericFilterBean {
 
-  Log logger = LogFactory.getLog(OutOfBandUserFilter.class);
+  Logger logger = LoggerFactory.getLogger(OutOfBandUserFilter.class);
   
   AuthenticationProvider authenticationProvider = null;
   OutOfBandUserFetcher outOfBandUserFetcher = null;

--- a/src/main/java/org/opendatakit/common/security/spring/RedirectingLoginUrlAuthenticationEntryPoint.java
+++ b/src/main/java/org/opendatakit/common/security/spring/RedirectingLoginUrlAuthenticationEntryPoint.java
@@ -21,8 +21,8 @@ import java.net.URLEncoder;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.util.RedirectUrlBuilder;
@@ -37,7 +37,7 @@ import org.springframework.security.web.util.UrlUtils;
  */
 public class RedirectingLoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticationEntryPoint {
   
-  private Log logger = LogFactory.getLog(RedirectingLoginUrlAuthenticationEntryPoint.class);
+  private Logger logger = LoggerFactory.getLogger(RedirectingLoginUrlAuthenticationEntryPoint.class);
   
   public RedirectingLoginUrlAuthenticationEntryPoint(String loginFormUrl) {
     super(loginFormUrl);

--- a/src/main/java/org/opendatakit/common/security/spring/RegisteredUsersTable.java
+++ b/src/main/java/org/opendatakit/common/security/spring/RegisteredUsersTable.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
@@ -75,7 +75,7 @@ import org.springframework.security.authentication.encoding.MessageDigestPasswor
  */
 public final class RegisteredUsersTable extends CommonFieldsBase {
 
-  private static final Log logger = LogFactory.getLog(RegisteredUsersTable.class);
+  private static final Logger logger = LoggerFactory.getLogger(RegisteredUsersTable.class);
 
   // prefix that identifies a user id
   // user ids are of the form uid:username|yyyyMMddTHHmmSS

--- a/src/main/java/org/opendatakit/common/security/spring/RoleHierarchyImpl.java
+++ b/src/main/java/org/opendatakit/common/security/spring/RoleHierarchyImpl.java
@@ -30,8 +30,8 @@ import java.util.UUID;
 
 import javax.servlet.ServletContext;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.constants.TaskLockType;
 import org.opendatakit.common.persistence.Datastore;
 import org.opendatakit.common.persistence.PersistConsts;
@@ -63,7 +63,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
  */
 public class RoleHierarchyImpl implements RoleHierarchy, InitializingBean {
 
-    private static final Log logger = LogFactory.getLog(RoleHierarchyImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(RoleHierarchyImpl.class);
     // look for flagged changes every CHECK_INTERVAL.
     private static final long CHECK_INTERVAL = 1000L; // 1 seconds
     // refresh everything every UPDATE_INTERVAL.

--- a/src/main/java/org/opendatakit/common/security/spring/TargetUrlRequestAwareAuthenticationSuccessHandler.java
+++ b/src/main/java/org/opendatakit/common/security/spring/TargetUrlRequestAwareAuthenticationSuccessHandler.java
@@ -21,8 +21,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
@@ -39,7 +39,7 @@ import org.springframework.util.StringUtils;
  *
  */
 public class TargetUrlRequestAwareAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-  protected final Log logger = LogFactory.getLog(this.getClass());
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private RequestCache requestCache = new HttpSessionRequestCache();
 

--- a/src/main/java/org/opendatakit/common/security/spring/UserServiceImpl.java
+++ b/src/main/java/org/opendatakit/common/security/spring/UserServiceImpl.java
@@ -23,8 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.opendatakit.common.persistence.Datastore;
 import org.opendatakit.common.persistence.Query;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
@@ -47,7 +47,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class UserServiceImpl implements org.opendatakit.common.security.UserService,
     InitializingBean {
 
-  private static final Log logger = LogFactory.getLog(UserServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
 
   // configured by bean definition...
   Datastore datastore;
@@ -81,7 +81,7 @@ public class UserServiceImpl implements org.opendatakit.common.security.UserServ
       throw new IllegalStateException("superUserEmail is malformed. "
           + "Must be of the form 'mailto:user@gmail.com' or other supported OAuth2 provider.");
     }
-    Log log = LogFactory.getLog(UserServiceImpl.class);
+    Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
     log.info("superUserEmail: " + superUserEmail);
     log.info("superUserUsername: " + superUserUsername);
 

--- a/src/main/java/org/opendatakit/common/utils/WebUtils.java
+++ b/src/main/java/org/opendatakit/common/utils/WebUtils.java
@@ -32,8 +32,8 @@ import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.javarosa.core.model.utils.DateUtils;
@@ -53,7 +53,7 @@ public class WebUtils {
   static final String ATTRIBUTE_VALUE_TAG = "attributeValue";
   static final String ATTRIBUTE_NAME_TAG = "attributeName";
   static final String CURSOR_TAG = "cursor";
-  static final Log logger = LogFactory.getLog(WebUtils.class);
+  static final Logger logger = LoggerFactory.getLogger(WebUtils.class);
   /**
    * Date format pattern used to parse HTTP date headers in RFC 1123 format.
    * copied from apache.commons.lang.DateUtils

--- a/src/main/java/org/opendatakit/common/web/servlet/CommonServletBase.java
+++ b/src/main/java/org/opendatakit/common/web/servlet/CommonServletBase.java
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
+import org.slf4j.Logger;
 import org.opendatakit.common.security.spring.SpringInternals;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
@@ -58,7 +58,7 @@ public abstract class CommonServletBase extends HttpServlet {
      this.applicationName = applicationName;
   }
 
-  protected Map<String,String> parseParameterMap(HttpServletRequest request, Log logger) {
+  protected Map<String,String> parseParameterMap(HttpServletRequest request, Logger logger) {
 
     Map<String, String> parameters = new HashMap<String,String>();
     @SuppressWarnings("rawtypes")

--- a/src/main/resources/security.properties
+++ b/src/main/resources/security.properties
@@ -28,7 +28,7 @@ security.server.channelType=REQUIRES_INSECURE_CHANNEL
 # external services.
 #
 # This is configured during install.  If blank, discovers an IP address
-security.server.hostname=localhost
+security.server.hostname=
 security.server.port=8080
 security.server.securePort=8443
 


### PR DESCRIPTION
This PR adds some dependencies to the project to be able to **migrate all logging code to SLF4J**

It includes the JUL binding as a default and comes also with JCL and Log4J to SLF4J bridges, meaning that:
- We write code that uses SLF4J API directly
- Third party libraries that use Log4J or JCL get routed to SLF4J
- JUL is what ultimately writes log lines however it's configured on the `logging.properties` files.

This PR also reviews the logging code around the `UploadSubmissionsWorkerImpl` class and the Google API external service classes.