### PR TITLE
Fix installer generation docs with updated gradle task name

### DIFF
--- a/docs/installer-generation.md
+++ b/docs/installer-generation.md
@@ -12,8 +12,7 @@ You can download it from [this website](https://installbuilder.bitrock.com/).
 
 ## Instructions
 
-1. Build the project for the installer build process with `./gradlew clean build -x test -PwarMode=installer` command
-2. Build the installer project with `./gradlew buildInstaller` command
-5. Open BitRock InstallBuilder app and open `build/installer/buildWar.xml`
+1. Build the project for the installer build process with `./gradlew clean build installerBuild -xtest -PwarMode=installer` command
+2. Open BitRock InstallBuilder app and open `build/installer/buildWar.xml`
 
 For more information about using BitRock InstallBuilder, you can check the [online documentation](https://installbuilder.bitrock.com/docs/installbuilder-userguide/index.html)


### PR DESCRIPTION
With last PRs, I normalized task names to follow the same schema of `contextAction` like `gaeUpdate`, or `packerBuild`. 

I had to change the installer tasks and I forgot to update the docs (and tell anyone about this, sorry!)

#### What has been done to verify that this works as intended?
Run changed tasks on my computer

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
None

#### Do we need any specific form for testing your changes? If so, please attach one.
Nope