### PR TITLE
1.5.0 release fixes

### DIFF
--- a/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/gae/Rollback.groovy
+++ b/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/gae/Rollback.groovy
@@ -29,7 +29,7 @@ class Rollback extends JavaExec {
   }
 
   String getSDKHome() {
-    return "${getWorkingDir()}/appengine-java-sdk-1.9.54".toString()
+    return "${getWorkingDir()}/appengine-java-sdk-1.9.63".toString()
   }
 
   String getDummyAppPath() {

--- a/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/gae/Update.groovy
+++ b/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/gae/Update.groovy
@@ -18,7 +18,7 @@ class Update extends JavaExec {
   }
 
   String getSDKHome() {
-    return "${getWorkingDir()}/appengine-java-sdk-1.9.54".toString()
+    return "${getWorkingDir()}/appengine-java-sdk-1.9.63".toString()
   }
 
   String getEarPath() {

--- a/gae.gradle
+++ b/gae.gradle
@@ -8,9 +8,9 @@ import static org.opendatakit.aggregate.gradle.Util.truncate
 task gaeDownloadSDK() {
   doLast {
     if (!file('installer/appEngineSDK.zip').exists()) {
-      println("Downloading App Engine SDK 1.9.54")
+      println("Downloading App Engine SDK 1.9.63")
       download {
-        src 'https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.54.zip'
+        src 'https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.63.zip'
         dest 'installer/appEngineSDK.zip'
       }
     } else

--- a/installer.gradle
+++ b/installer.gradle
@@ -34,6 +34,6 @@ task installerBuild(dependsOn: [installerClean, gaeDownloadSDK], type: Copy) {
   doLast {
     setXmlValue("${buildDir}/installer/buildWar.xml", "version", version)
     file("${buildDir}/installer/files/${archivesBaseName}-${version}.war").renameTo(file("build/installer/files/ODKAggregate.war"))
-    file("${buildDir}/installer/files/appengine-java-sdk-1.9.54").renameTo(file("build/installer/files/appengine-java-sdk"))
+    file("${buildDir}/installer/files/appengine-java-sdk-1.9.63").renameTo(file("build/installer/files/appengine-java-sdk"))
   }
 }

--- a/installer.gradle
+++ b/installer.gradle
@@ -35,5 +35,15 @@ task installerBuild(dependsOn: [installerClean, gaeDownloadSDK], type: Copy) {
     setXmlValue("${buildDir}/installer/buildWar.xml", "version", version)
     file("${buildDir}/installer/files/${archivesBaseName}-${version}.war").renameTo(file("build/installer/files/ODKAggregate.war"))
     file("${buildDir}/installer/files/appengine-java-sdk-1.9.63").renameTo(file("build/installer/files/appengine-java-sdk"))
+    delete "${buildDir}/installer/files/appengine-java-sdk/demos"
+    delete "${buildDir}/installer/files/appengine-java-sdk/docs/endpoints"
+    delete "${buildDir}/installer/files/appengine-java-sdk/docs/javadoc"
+    delete "${buildDir}/installer/files/appengine-java-sdk/docs/remoteapi"
+    delete "${buildDir}/installer/files/appengine-java-sdk/docs/spi"
+    delete "${buildDir}/installer/files/appengine-java-sdk/docs/testing"
+    delete "${buildDir}/installer/files/appengine-java-sdk/docs/tools"
+    delete "${buildDir}/installer/files/appengine-java-sdk/jetty93"
+    delete "${buildDir}/installer/files/appengine-java-sdk/jetty93-base"
+    delete "${buildDir}/installer/files/appengine-java-sdk/src"
   }
 }


### PR DESCRIPTION
Closes #227 
Closes #228

#### What has been done to verify that this works as intended?
- Build the installer 
- Run the installer with Java 8 (8u161-oracle) and Java 9 (9.0.4-oracle)
- Deploy with `gradlew gaeUpdate`
- Installer size (linux x64) is 157MB
- `du -h`  on install location reports 298MB, 145MB of them by the AppEngine SDK

#### Why is this the best possible solution? Were any other approaches considered?
This is the quickest fix that feels safe

#### Are there any risks to merging this code? If so, what are they?
Nope

#### Do we need any specific form for testing your changes? If so, please attach one.
Nope