### PR TITLE
Add unattended security updates

### DIFF
--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -8,3 +8,4 @@
     - tomcat
     - postgresql
     - aggregate
+    - unattended-upgrades

--- a/packer/ansible/roles/unattended-upgrades/tasks/main.yml
+++ b/packer/ansible/roles/unattended-upgrades/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: install
+  apt:
+    pkg: unattended-upgrades
+    state: installed
+
+- name: run security-updates
+  command: unattended-upgrades -v


### PR DESCRIPTION
Closes #233

#### What has been done to verify that this works as intended?
Confirmed that the unattended-upgrades was installed in the ova and updates were not needed. That is, the updates had run.

#### Why is this the best possible solution? Were any other approaches considered?
Followed the instructions at https://wiki.debian.org/UnattendedUpgrades#Unattended_Upgrades

#### Are there any risks to merging this code? If so, what are they?
Nothing relly