### PR TITLE
Fix unsafe html strings

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/OdkTablesManageInstanceFilesSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/OdkTablesManageInstanceFilesSubTab.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.OdkTablesTabUI.TablesChangeNotification;
@@ -200,8 +201,7 @@ public class OdkTablesManageInstanceFilesSubTab extends AggregateSubTabBase
       tableFileData.updateDisplay(currentTable);
 
       selectTablePanel.setHTML(2, 0, "<h2 id=\"table_displayed\"> Displaying: </h2>");
-      selectTablePanel.setHTML(2, 1, "<h2 id=\table_name\"> " + currentTable.getTableId()
-          + " </h2>");
+      selectTablePanel.setHTML(2, 1, new SafeHtmlBuilder().appendHtmlConstant("<h2 id=\table_name\">").appendEscaped(" " + currentTable.getTableId() + " ").appendHtmlConstant("</h2>").toSafeHtml());
       add(tableFileData);
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/OdkTablesManageTableFilesSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/OdkTablesManageTableFilesSubTab.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.OdkTablesTabUI.TablesChangeNotification;
@@ -229,8 +230,7 @@ public class OdkTablesManageTableFilesSubTab extends AggregateSubTabBase impleme
       tableFileData.updateDisplay(currentTable);
 
       selectTablePanel.setHTML(2, 0, "<h2 id=\"table_displayed\"> Displaying: </h2>");
-      selectTablePanel.setHTML(2, 1, "<h2 id=\table_name\"> " + currentTable.getTableId()
-          + " </h2>");
+      selectTablePanel.setHTML(2, 1, new SafeHtmlBuilder().appendHtmlConstant("<h2 id=\table_name\">").appendEscaped(" " + currentTable.getTableId() + " ").appendHtmlConstant("</h2>").toSafeHtml());
       add(tableFileData);
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/OdkTablesViewTableSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/OdkTablesViewTableSubTab.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.OdkTablesTabUI.TablesChangeNotification;
@@ -212,8 +213,7 @@ public class OdkTablesViewTableSubTab extends AggregateSubTabBase implements Tab
       tableData.updateDisplay(currentTable);
 
       selectTablePanel.setHTML(1, 0, "<h2 id=\"table_displayed\"> Displaying: </h2>");
-      selectTablePanel.setHTML(1, 1, "<h2 id=\table_name\"> " + currentTable.getTableId()
-          + " </h2>");
+      selectTablePanel.setHTML(1, 1, new SafeHtmlBuilder().appendHtmlConstant("<h2 id=\table_name\">").appendEscaped(" " + currentTable.getTableId() + " ").appendHtmlConstant("</h2>").toSafeHtml());
       selectTablePanel.setWidget(1,  2, tableAdvanceButton);
       add(tableData);
     }

--- a/src/main/java/org/opendatakit/aggregate/client/popups/AuditCSVPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/AuditCSVPopup.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HTML;
@@ -57,18 +59,19 @@ public class AuditCSVPopup extends AbstractPopupBase {
       public void onSuccess(String csvContents) {
         String[] allLines = csvContents.split("\n");
 
-        StringBuilder html = new StringBuilder("<table class=\"dataTable\">");
+        SafeHtmlBuilder builder = new SafeHtmlBuilder();
+        builder.appendHtmlConstant("<table class=\"dataTable\">")
+            .appendHtmlConstant("<tr class=\"titleBar\">")
+            .appendHtmlConstant("<td>Event</td><td>Node</td><td>Start</td><td>End</td>")
+            .appendHtmlConstant("</tr>");
 
-        html.append("<tr class=\"titleBar\">")
-            .append("<td>Event</td><td>Node</td><td>Start</td><td>End</td>")
-            .append("</tr>");
         for (int i = 1, max = allLines.length; i < max; i++) {
-          html.append(Row.from(allLines[i]).asTr());
+          builder.append(Row.from(allLines[i]).asTr());
         }
-        html.append("</table>");
+        builder.appendHtmlConstant("</table>");
 
         AggregateUI.getUI().clearError();
-        panel.add(new HTML(html.toString()));
+        panel.add(new HTML(builder.toSafeHtml()));
         AggregateUI.resize();
       }
     };
@@ -99,13 +102,15 @@ public class AuditCSVPopup extends AbstractPopupBase {
       );
     }
 
-    String asTr() {
-      return "<tr>" +
-          "<td>" + this.event + "</td>" +
-          "<td>" + this.node + "</td>" +
-          "<td>" + this.start.toString() + "</td>" +
-          "<td>" + this.getEnd() + "</td>" +
-          "</tr>";
+    SafeHtml asTr() {
+      return new SafeHtmlBuilder()
+          .appendHtmlConstant("<tr>")
+          .appendHtmlConstant("<td>").appendEscaped(this.event).appendHtmlConstant("</td>")
+          .appendHtmlConstant("<td>").appendEscaped(this.node).appendHtmlConstant("</td>")
+          .appendHtmlConstant("<td>").appendEscaped(this.start.toString()).appendHtmlConstant("</td>")
+          .appendHtmlConstant("<td>").appendEscaped(this.getEnd()).appendHtmlConstant("</td>")
+          .appendHtmlConstant("</tr>")
+          .toSafeHtml();
     }
 
     String getEnd() {

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ChangePasswordPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ChangePasswordPopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
 import org.opendatakit.aggregate.client.widgets.ExecuteChangePasswordButton;
 import org.opendatakit.common.security.client.UserSecurityInfo;
@@ -40,7 +41,7 @@ public class ChangePasswordPopup extends PopupPanel {
 
         FlexTable layout = new FlexTable();
         layout.setWidget(0, 0,
-                new HTML("Change Password for " + user.getUsername()));
+                new HTML(new SafeHtmlBuilder().appendEscaped("Change Password for " + user.getUsername()).toSafeHtml()));
         layout.setWidget(1, 0, new HTML("Password:"));
         layout.setWidget(1, 1, password1);
         layout.setWidget(2, 0, new HTML("Password (again):"));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmExportDeletePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmExportDeletePopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.form.ExportSummary;
@@ -59,8 +60,8 @@ public final class ConfirmExportDeletePopup extends AbstractPopupBase {
 
     FlexTable layout = new FlexTable();
 
-    HTML message = new HTML("Delete this exported datafile?" + "<br/>Do you wish to " + action
-        + " this exported datafile?");
+    HTML message = new HTML(new SafeHtmlBuilder().appendEscaped("Delete this exported datafile?" + "<br/>Do you wish to " + action
+        + " this exported datafile?").toSafeHtml());
     layout.setWidget(0, 0, message);
     layout.setWidget(0, 1, deleteButton);
     layout.setWidget(0, 2, new ClosePopupButton(this));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmFormDeletePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmFormDeletePopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
@@ -47,10 +48,10 @@ public final class ConfirmFormDeletePopup extends AbstractPopupBase {
     
     FlexTable layout = new FlexTable();
 
-    HTML message = new HTML(
+    HTML message = new HTML(new SafeHtmlBuilder().appendEscaped(
         "Delete all data and the form definition for <b>"
             + formId
-            + "</b>?<br/>Do you wish to delete all uploaded data and the form definition for this form?");
+            + "</b>?<br/>Do you wish to delete all uploaded data and the form definition for this form?").toSafeHtml());
     layout.setWidget(0, 0, message);
     layout.setWidget(0, 1, deleteButton);
     layout.setWidget(0, 2, new ClosePopupButton(this));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPublishDeletePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPublishDeletePopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
@@ -60,8 +61,8 @@ public final class ConfirmPublishDeletePopup extends AbstractPopupBase {
 
     FlexTable layout = new FlexTable();
 
-    HTML message = new HTML("Delete this publisher?" + "<br/>Do you wish to " + action
-        + " this location?");
+    HTML message = new HTML(new SafeHtmlBuilder().appendEscaped("Delete this publisher?" + "<br/>Do you wish to " + action
+        + " this location?").toSafeHtml());
     layout.setWidget(0, 0, message);
     layout.setWidget(0, 1, deleteButton);
     layout.setWidget(0, 2, new ClosePopupButton(this));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgePopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtml;
 import java.util.Date;
 
 import org.opendatakit.aggregate.client.AggregateUI;
@@ -40,7 +41,7 @@ public class ConfirmPurgePopup extends AbstractPopupBase {
   private String uri;
   private Date earliest;
 
-  public ConfirmPurgePopup(ExternServSummary e, Date earliest, String bodyText) {
+  public ConfirmPurgePopup(ExternServSummary e, Date earliest, SafeHtml bodyText) {
     super();
 
     this.uri = e.getUri();

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
@@ -26,6 +26,8 @@ import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.FlexTable;
@@ -51,15 +53,16 @@ public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
     confirm.addClickHandler(new PurgeHandler());
 
     FlexTable layout = new FlexTable();
-    StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append("Delete submissions data of ");
-    stringBuilder.append(summary.getTitle());
-    stringBuilder.append(" [");
-    stringBuilder.append(summary.getId());
-    stringBuilder.append("] up through ");
-    stringBuilder.append(earliest.toGMTString());
-    stringBuilder.append(". Incomplete submissions will not be deleted.");
-    layout.setWidget(0, 0, new HTML(stringBuilder.toString()));
+    SafeHtml content = new SafeHtmlBuilder()
+        .appendEscaped("Delete submissions data of ")
+        .appendEscaped(summary.getTitle())
+        .appendEscaped(" [")
+        .appendEscaped(summary.getId())
+        .appendEscaped("] up through ")
+        .appendEscaped(earliest.toGMTString())
+        .appendEscaped(". Incomplete submissions will not be deleted.")
+        .toSafeHtml();
+    layout.setWidget(0, 0, new HTML(content));
     layout.setWidget(0, 1, confirm);
     layout.setWidget(0, 2, new ClosePopupButton(this));
     setWidget(layout);

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmUserDeletePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmUserDeletePopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.permissions.AccessConfigurationSheet;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
@@ -53,16 +54,17 @@ public final class ConfirmUserDeletePopup extends AbstractPopupBase {
 
     HTML message;
     if (sheet.isUiOutOfSyncWithServer()) {
-      message = new HTML(
+      message = new HTML(new SafeHtmlBuilder().appendEscaped(
           "Unsaved changes exist.<br/>"
               + "<p>Proceeding will save all pending changes and<br/>permanently delete user <b>"
               + userToDelete.getCanonicalName()
               + "</b> on the server.</p>"
-              + "<p>Do you wish to apply all pending changes and <br/>permanently delete this user?</p>");
+              + "<p>Do you wish to apply all pending changes and <br/>permanently delete this user?</p>").toSafeHtml());
     } else {
-      message = new HTML("<p>Proceeding will permanently delete user <b>"
+      message = new HTML(new SafeHtmlBuilder().appendEscaped(
+          "<p>Proceeding will permanently delete user <b>"
           + userToDelete.getCanonicalName()
-          + "</b> on the server.</p><p>Do you wish to permanently delete this user?</p>");
+          + "</b> on the server.</p><p>Do you wish to permanently delete this user?</p>").toSafeHtml());
     }
     layout.setWidget(0, 0, message);
     layout.setWidget(2, 0, deleteButton);

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
@@ -83,7 +84,7 @@ public final class ExportPopup extends AbstractPopupBase {
     optionsBar = new FlexTable();
     optionsBar.addStyleName("stretch_header");
     optionsBar.setWidget(0, 0, new HTML("<h2> Form:</h2>"));
-    optionsBar.setWidget(0, 1, new HTML(formId));
+    optionsBar.setWidget(0, 1, new HTML(new SafeHtmlBuilder().appendEscaped(formId).toSafeHtml()));
     optionsBar.setWidget(0, 2, new HTML("<h2>Type:</h2>"));
     optionsBar.setWidget(0, 3, fileType);
     optionsBar.setWidget(0, 4, new HTML("<h2>Filter:</h2>"));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/FilterPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/FilterPopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.filter.ColumnFilter;
@@ -126,7 +127,7 @@ public final class FilterPopup extends AbstractPopupBase {
         
         formDisplay = new FlexTable();
         formDisplay.setWidget(0, 0, new HTML("<h2>Form:</h2>"));
-        formDisplay.setWidget(0, 1, new HTML(filterGroup.getFormId()));
+        formDisplay.setWidget(0, 1, new HTML(new SafeHtmlBuilder().appendEscaped(filterGroup.getFormId()).toSafeHtml()));
         topBar.setWidget(0, 0, formDisplay);
         topBar.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_LEFT);
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/HelpBalloon.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/HelpBalloon.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.PopupPanel;
@@ -38,7 +39,7 @@ public class HelpBalloon extends PopupPanel {
     this.widget = sender;
     this.offsetX = offsetX;
     this.offsetY = offsetY;
-    add(new HTML(text));
+    add(new HTML(new SafeHtmlBuilder().appendEscaped(text).toSafeHtml()));
   }
 
   public void display() {

--- a/src/main/java/org/opendatakit/aggregate/client/popups/HelpBookPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/HelpBookPopup.java
@@ -44,6 +44,8 @@ public class HelpBookPopup extends PopupPanel {
     FlowPanel content = new FlowPanel(); // vertical
     content.setStylePrimaryName(UIConsts.VERTICAL_FLOW_PANEL_STYLENAME);
     for (int i = 0; i < consts.length; i++) {
+      // We won't escape these HTML strings using SafeHtmlBuilder because
+      // they don't come from user input (BookHelpConsts class)
       content.add(new HTML("<h2 id=\"form_name\">" + consts[i].getTitle() + "</h2>"));
 
       if (consts[i].getVideoUrl() != null) {

--- a/src/main/java/org/opendatakit/aggregate/client/popups/KmlGeoPointSettingsSelectionRow.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/KmlGeoPointSettingsSelectionRow.java
@@ -1,5 +1,6 @@
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.form.KmlGeopointOption;
 import org.opendatakit.aggregate.client.form.KmlOptionSetting;
 import org.opendatakit.aggregate.client.form.KmlSelection;
@@ -42,7 +43,7 @@ public class KmlGeoPointSettingsSelectionRow extends FlexTable implements KmlSel
     addStyleName("dataTable");
     setWidget(0, 0, include);
     setWidget(0, 1, new HTML("<h2>Geopoint:<h2>"));
-    setWidget(0, 2, new HTML(geoPoint.getDisplayName()));
+    setWidget(0, 2, new HTML(new SafeHtmlBuilder().appendEscaped(geoPoint.getDisplayName()).toSafeHtml()));
     setWidget(0, 3, new HTML("<h4>Title:<h4>"));
     setWidget(0, 4, titleFieldsDropDown);
     setWidget(0, 5, new HTML("<h4>Picture:<h4>"));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/KmlGeoTraceNShapeSelectionRow.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/KmlGeoTraceNShapeSelectionRow.java
@@ -1,5 +1,6 @@
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.form.KmlGeoTraceNShapeOption;
 import org.opendatakit.aggregate.client.form.KmlOptionSetting;
 import org.opendatakit.aggregate.client.form.KmlSelection;
@@ -40,7 +41,7 @@ public class KmlGeoTraceNShapeSelectionRow extends FlexTable implements KmlSelec
     } else {
       setWidget(0, 1, new HTML("<h2>Geoshape:<h2>"));
     }
-    setWidget(0, 2, new HTML(geoNode.getDisplayName()));
+    setWidget(0, 2, new HTML(new SafeHtmlBuilder().appendEscaped(geoNode.getDisplayName()).toSafeHtml()));
     setWidget(0, 3, new HTML("<h4>Name:<h4>"));
     setWidget(0, 4, nameDropDown);
   }

--- a/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
@@ -15,6 +15,7 @@
  */
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.AggregateUI;
@@ -73,9 +74,9 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
     topBar = new FlexTable();
     topBar.addStyleName("stretch_header");
     topBar.setWidget(0, 0, new HTML("<h2> Form:</h2>"));
-    topBar.setWidget(0, 1, new HTML(formId));
+    topBar.setWidget(0, 1, new HTML(new SafeHtmlBuilder().appendEscaped(formId).toSafeHtml()));
     topBar.setWidget(0, 2, new HTML("<h2>Filter:</h2>"));
-    topBar.setWidget(0, 3, new HTML(selectedFilterGroup.getName()));
+    topBar.setWidget(0, 3, new HTML(new SafeHtmlBuilder().appendEscaped(selectedFilterGroup.getName()).toSafeHtml()));
     topBar.setWidget(0, 6, exportButton);
     topBar.setWidget(0, 7, new ClosePopupButton(this));
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.UIUtils;
@@ -116,7 +117,7 @@ public final class PublishPopup extends AbstractPopupBase {
     topBar = new FlexTable();
     topBar.addStyleName("stretch_header");
     topBar.setWidget(0, 0, new HTML("<h2>Form: </h2>"));
-    topBar.setWidget(0, 1, new HTML(formId));
+    topBar.setWidget(0, 1, new HTML(new SafeHtmlBuilder().appendEscaped(formId).toSafeHtml()));
     topBar.setWidget(0, 2, new HTML("<h2>Publish to: </h2>"));
     topBar.setWidget(0, 3, serviceType);
     topBar.setWidget(0, 4, publishButton);

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PurgeUpToDatePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PurgeUpToDatePopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.Date;
 
 import org.opendatakit.aggregate.client.form.FormSummary;
@@ -66,8 +67,9 @@ public class PurgeUpToDatePopup extends AbstractPopupBase {
       }});
 
     FlexTable layout = new FlexTable();
-    layout.setWidget(0, 0, new HTML("Purge submissions data for:<br>"
-        + formSummary.getTitle() + " [" + formSummary.getId() + "]<br>up to the chosen GMT date.<br>Incomplete submissions will<br>not be deleted."));
+    layout.setWidget(0, 0, new HTML(new SafeHtmlBuilder().appendEscaped(
+        "Purge submissions data for:<br>"
+        + formSummary.getTitle() + " [" + formSummary.getId() + "]<br>up to the chosen GMT date.<br>Incomplete submissions will<br>not be deleted.").toSafeHtml()));
     layout.setWidget(0, 1, picker);
     layout.setWidget(0, 2, confirm);
     layout.setWidget(0, 3, new ClosePopupButton(this));

--- a/src/main/java/org/opendatakit/aggregate/client/popups/VisualizationPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/VisualizationPopup.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -248,7 +249,7 @@ public final class VisualizationPopup extends AbstractPopupBase {
     String chartTypeString = chartType.getSelectedValue();
     ChartType selected = (chartTypeString == null) ? null : ChartType.valueOf(chartTypeString);
 
-    executeButton.setHTML(selected.getButtonText());
+    executeButton.setHTML(new SafeHtmlBuilder().appendHtmlConstant(selected.getButtonText()).toSafeHtml());
     if (selected.equals(ChartType.MAP)) {
       typeControlBar.setHTML(0, COLUMN_TEXT, GPS_TXT);
       typeControlBar.setWidget(0, COLUMN_LIST, geoPoints);

--- a/src/main/java/org/opendatakit/aggregate/client/table/ExportTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/ExportTable.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.form.ExportSummary;
@@ -68,7 +69,7 @@ public class ExportTable extends FlexTable {
       if (e.getStatus() != null) {
         this.setText(i + STARTING_ROW, STATUS, e.getStatus().toString());
         if (e.getResultFile() != null && e.getStatus() == ExportStatus.AVAILABLE) {
-          this.setWidget(i + STARTING_ROW, DOWNLOAD_FILE, new HTML(e.getResultFile()));
+          this.setWidget(i + STARTING_ROW, DOWNLOAD_FILE, new HTML(new SafeHtmlBuilder().appendEscaped(e.getResultFile()).toSafeHtml()));
         }
       }
       this.setWidget(i + STARTING_ROW, DELETE, new DeleteExportButton(e));

--- a/src/main/java/org/opendatakit/aggregate/client/table/FormTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/FormTable.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.form.FormSummary;
@@ -98,8 +99,8 @@ public class FormTable extends FlexTable {
       }
       // ok -- we should show this form...
       ++i;
-      setWidget(i, TITLE_COLUMN, new HTML(form.getViewableURL()));
-      setWidget(i, FORM_ID_COLUMN, new HTML(form.getId()));
+      setWidget(i, TITLE_COLUMN, new HTML(new SafeHtmlBuilder().appendHtmlConstant(form.getViewableURL()).toSafeHtml()));
+      setWidget(i, FORM_ID_COLUMN, new HTML(new SafeHtmlBuilder().appendEscaped(form.getId()).toSafeHtml()));
 
       Widget mediaCount;
       if (form.getMediaFileCount() > 0) {
@@ -107,7 +108,7 @@ public class FormTable extends FlexTable {
         mediaCountLink.addClickHandler(new MediaFileListClickHandler(form.getId()));
         mediaCount = mediaCountLink;
       } else {
-        mediaCount = new HTML(Integer.toString(form.getMediaFileCount()));
+        mediaCount = new HTML(new SafeHtmlBuilder().appendEscaped(Integer.toString(form.getMediaFileCount())).toSafeHtml());
       }
       setWidget(i, MEDIA_COUNT_COLUMN, mediaCount);
 

--- a/src/main/java/org/opendatakit/aggregate/client/table/OdkAdminListTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/OdkAdminListTable.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.preferences.OdkTablesAdmin;
 import org.opendatakit.aggregate.client.widgets.TablesAdminDeleteButton;
 
@@ -58,8 +59,8 @@ public class OdkAdminListTable extends FlexTable {
       OdkTablesAdmin admin = adminList[i];
       int j = i + 1;
       setWidget(j, DELETE_COLUMN, new TablesAdminDeleteButton(admin.getUriUser()));
-      setWidget(j, USER_COLUMN, new HTML(admin.getName()));
-      setWidget(j, ODK_TABLES_USER_ID_COLUMN, new HTML(admin.getOdkTablesUserId()));
+      setWidget(j, USER_COLUMN, new HTML(new SafeHtmlBuilder().appendEscaped(admin.getName()).toSafeHtml()));
+      setWidget(j, ODK_TABLES_USER_ID_COLUMN, new HTML(new SafeHtmlBuilder().appendEscaped(admin.getOdkTablesUserId()).toSafeHtml()));
 
       if (j % 2 == 0)
         getRowFormatter().addStyleName(j, "evenTableRow");

--- a/src/main/java/org/opendatakit/aggregate/client/table/OdkTablesTableList.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/OdkTablesTableList.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.AggregateUI;
@@ -96,7 +97,7 @@ public class OdkTablesTableList extends FlexTable {
         // this will maintain the row you're adding to, always +1
         // because of the title row
         int j = i + 1;
-        setWidget(j, TABLE_ID_COLUMN, new HTML("<b>" + table.getTableId() + "</b>"));
+        setWidget(j, TABLE_ID_COLUMN, new HTML(new SafeHtmlBuilder().appendHtmlConstant("<b>").appendEscaped(table.getTableId()).appendHtmlConstant("</b>").toSafeHtml()));
         OdkTablesDeleteTableButton deleteButton = new OdkTablesDeleteTableButton(this,
             table.getTableId());
         if (!AggregateUI.getUI().getUserInfo().getGrantedAuthorities()

--- a/src/main/java/org/opendatakit/aggregate/client/table/OdkTablesViewTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/OdkTablesViewTable.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.AggregateSubTabBase;
@@ -347,24 +348,24 @@ public class OdkTablesViewTable extends FlexTable {
           setWidget(currentRow, 0, deleteButton);
           int j = 1;
           for (String column : columnNames) {
-            setWidget(currentRow, j, new HTML(row.getValues().get(column)));
+            setWidget(currentRow, j, new HTML(new SafeHtmlBuilder().appendEscaped(row.getValues().get(column)).toSafeHtml()));
             j++;
           }
-          setWidget(currentRow, j++, new HTML(row.getSavepointType()));
-          setWidget(currentRow, j++, new HTML(row.getFormId()));
-          setWidget(currentRow, j++, new HTML(row.getLocale()));
-          setWidget(currentRow, j++, new HTML(row.getSavepointTimestampIso8601Date()));
-          setWidget(currentRow, j++, new HTML(row.getSavepointCreator()));
-          setWidget(currentRow, j++, new HTML(row.getRowId()));
-          setWidget(currentRow, j++, new HTML(row.getRowETag()));
-          setWidget(currentRow, j++, new HTML(row.getRowFilterScope().getAccess().name()));
-          setWidget(currentRow, j++, new HTML(row.getRowFilterScope().getRowOwner()));
-          setWidget(currentRow, j++, new HTML(row.getRowFilterScope().getGroupReadOnly()));
-          setWidget(currentRow, j++, new HTML(row.getRowFilterScope().getGroupModify()));
-          setWidget(currentRow, j++, new HTML(row.getRowFilterScope().getGroupPrivileged()));
-          setWidget(currentRow, j++, new HTML(row.getLastUpdateUser()));
-          setWidget(currentRow, j++, new HTML(row.getCreateUser()));
-          setWidget(currentRow, j++, new HTML(row.getDataETagAtModification()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getSavepointType()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getFormId()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getLocale()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getSavepointTimestampIso8601Date()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getSavepointCreator()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowId()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowETag()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowFilterScope().getAccess().name()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowFilterScope().getRowOwner()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowFilterScope().getGroupReadOnly()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowFilterScope().getGroupModify()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getRowFilterScope().getGroupPrivileged()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getLastUpdateUser()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getCreateUser()).toSafeHtml()));
+          setWidget(currentRow, j++, new HTML(new SafeHtmlBuilder().appendEscaped(row.getDataETagAtModification()).toSafeHtml()));
 
           if (currentRow % 2 == 0) {
             getRowFormatter().addStyleName(currentRow, "evenTableRow");

--- a/src/main/java/org/opendatakit/aggregate/client/table/PublishTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/PublishTable.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.Date;
 
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
@@ -94,8 +95,8 @@ public class PublishTable extends FlexTable {
       this.setText(i + STARTING_ROW, TIME_PUBLISH_START, e.getTimeEstablished().toString());
       this.setText(i + STARTING_ROW, ACTION, e.getPublicationOption().getDescriptionOfOption());
       this.setText(i + STARTING_ROW, TYPE, e.getExternalServiceType().getDisplayText());
-      this.setWidget(i + STARTING_ROW, OWNERSHIP, new HTML(e.getOwnership()));
-      this.setWidget(i + STARTING_ROW, NAME, new HTML(e.getName()));
+      this.setWidget(i + STARTING_ROW, OWNERSHIP, new HTML(new SafeHtmlBuilder().appendEscaped(e.getOwnership()).toSafeHtml()));
+      this.setWidget(i + STARTING_ROW, NAME, new HTML(new SafeHtmlBuilder().appendEscaped(e.getName()).toSafeHtml()));
       this.setWidget(i + STARTING_ROW, DELETE,  new DeletePublishButton(e));
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/table/SubmissionPaginationNavBar.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/SubmissionPaginationNavBar.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.client.submission.SubmissionUISummary;
 import org.opendatakit.aggregate.client.widgets.CursorAdvancementButton;
@@ -44,7 +45,7 @@ public class SubmissionPaginationNavBar extends SimplePanel {
     // create previous button
     controls.setWidget(0, 0, new CursorAdvancementButton(summary, group, false));
 
-    controls.setHTML(0, 1, "<h2 id=\"form_name\">" + summary.getFormTitle() + "</h2>");
+    controls.setHTML(0, 1, new SafeHtmlBuilder().appendHtmlConstant("<h2 id=\"form_name\">").appendEscaped(summary.getFormTitle()).appendHtmlConstant("</h2>").toSafeHtml());
 
     // create next button
     controls.setWidget(0, 2, new CursorAdvancementButton(summary, group, true));

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/AggregateCheckBox.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/AggregateCheckBox.java
@@ -18,6 +18,7 @@ package org.opendatakit.aggregate.client.widgets;
 
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.CheckBox;
 
 public class AggregateCheckBox extends CheckBox implements ValueChangeHandler<Boolean> {
@@ -37,7 +38,7 @@ public class AggregateCheckBox extends CheckBox implements ValueChangeHandler<Bo
     
     if(label != null) {
       if(labelIsHTML) {
-        setHTML(label);
+        setHTML(new SafeHtmlBuilder().appendHtmlConstant(label).toSafeHtml());
       } else {
         setText(label);
       }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/PurgeButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/PurgeButton.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.client.widgets;
 
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import java.util.Date;
 
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
@@ -72,20 +73,24 @@ public final class PurgeButton extends AggregateButton implements ClickHandler {
       break;
     }
 
-    StringBuilder b = new StringBuilder();
+    SafeHtmlBuilder b = new SafeHtmlBuilder();
     if (earliest == null) {
       Window.alert("Data has not yet been published -- no data will be purged");
     } else {
       if (externServ.getPublicationOption() != ExternalServicePublicationOption.UPLOAD_ONLY) {
-        b.append("<p><b>Note:</b> Even though the chosen publishing action involves an ongoing streaming"
-            + " of data to the external service, this purge action is a one-time event and is "
-            + "not automatically ongoing.  You will need to periodically repeat this process.</p>");
+        b.appendHtmlConstant("<p>")
+            .appendHtmlConstant("<b>Note:</b>")
+            .appendEscaped("Even though the chosen publishing action involves an ongoing streaming ")
+            .appendEscaped("of data to the external service, this purge action is a one-time event and is ")
+            .appendEscaped("not automatically ongoing.  You will need to periodically repeat this process.")
+            .appendHtmlConstant("</p>");
       }
-      b.append("Click to confirm purge of <b>" + formId + "</b> submissions older than "
-          + earliest.toString());
+      b.appendEscaped("Click to confirm purge of ")
+          .appendHtmlConstant("<b>").appendEscaped(formId).appendHtmlConstant("</b>")
+          .appendEscaped(" submissions older than " + earliest.toString());
 
       // TODO: display pop-up with text from b...
-      final ConfirmPurgePopup popup = new ConfirmPurgePopup(externServ, earliest, b.toString());
+      final ConfirmPurgePopup popup = new ConfirmPurgePopup(externServ, earliest, b.toSafeHtml());
       popup.setPopupPositionAndShow(popup.getPositionCallBack());
     }
   }


### PR DESCRIPTION
This PR changes some unsafe uses of HTML and html-capable GWT widgets using SafeHtml instances to ensure dynamic strings are properly escaped.

(GitHub detects changes on whole files for some reason... ignoring whitespaces while reviewing is recommended)

#### What has been done to verify that this works as intended?
Manually browsed Aggregate screens.

#### Why is this the best possible solution? Were any other approaches considered?
This is just what the GWT recommends when dealing with dynamic html content.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
N/A

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.