### PR TITLE
Jr 2 10 0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ def versions = [
     gson          : '2.8.0',
     kxml2         : '2.3.0',
     odk           : [
-        javarosa     : '2.6.0',
+        javarosa     : '2.10.0',
         httpclientGae: '4.5.2-1',
         tomcatUtil   : '1.0.1'
     ],


### PR DESCRIPTION
This PR replaces #246 (I closed it and GitHub wouldn't let me reopen it after rebasing some commits)

#### What has been done to verify that this works as intended?
- I have compiled and launched Aggregate on Tomcat and GAE.
- I have uploaded a form with two fields with `odk:length` attributes and tested that answers where being truncated at the correct sizes.
    This is the form I've used: [basic_odk_length.txt](https://github.com/opendatakit/aggregate/files/2042462/basic_odk_length.txt)
- To test that form change detection worked, I uploaded the form with one field first, and then I uploaded the complete form having changed the version.

#### Why is this the best possible solution? Were any other approaches considered?
The original implementation used extension of JR artifacts that now are private and can't be extended.

This PR replaces that with some post-processing of the form after being parsed:
- Read any `odk:length` attribute on bindings to correctly size storage fields
- Store original bindings to be able to compare form changes

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.