### PR TITLE
Issue 255 Fix NPE when uploading a new form version

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -418,6 +418,7 @@ public class BaseFormParserForJavaRosa {
     try (StringReader isr = new StringReader(xml)) {
       KXmlParser parser = new KXmlParser();
       parser.setInput(isr);
+      parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
       doc.parse(parser);
     } catch (IOException | XmlPullParserException e) {
       throw new ODKIncompleteSubmissionData(

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -418,10 +418,7 @@ public class BaseFormParserForJavaRosa {
     Document doc = parseXmlToDocument(xml);
 
     List<Element> allBindings = getBindings(doc);
-
-
-    // Copy binding for later use
-    allBindings.forEach(e -> bindElements.add(copyBindingElement(e)));
+    allBindings.forEach(this::storeCopyOfBinding);
 
     // Set lengths of fields if odk:length has been defined
     allBindings.forEach(e -> Optional
@@ -596,6 +593,20 @@ public class BaseFormParserForJavaRosa {
     }
     // clean illegal characters from title
     title = formTitle.replace(BasicConsts.FORWARDSLASH, BasicConsts.EMPTY_STRING);
+  }
+
+  /**
+   * Gets a copy of the given {@link Element} and saves it to be used if
+   * we need to compute the diff between the parsed xml and another xml
+   */
+  private void storeCopyOfBinding(Element binding) {
+    Element copy = new Element();
+    copy.createElement(binding.getNamespace(), binding.getName());
+    for (int i = 0; i < binding.getAttributeCount(); i++) {
+      copy.setAttribute(binding.getAttributeNamespace(i), binding.getAttributeName(i),
+          binding.getAttributeValue(i));
+    }
+    bindElements.add(copy);
   }
 
   private static List<Element> getBindings(Document doc) throws ODKIncompleteSubmissionData {
@@ -1103,18 +1114,6 @@ public class BaseFormParserForJavaRosa {
       if ((retval = element.getAttributeValue(attributeNamespace, attributeName)) != null) {
         return (retval);
       }
-    }
-    return (retval);
-  }
-
-  // copy binding and associated attributes to a new binding element (to help
-  // with maintaining list of original bindings)
-  private static Element copyBindingElement(Element element) {
-    Element retval = new Element();
-    retval.createElement(element.getNamespace(), element.getName());
-    for (int i = 0; i < element.getAttributeCount(); i++) {
-      retval.setAttribute(element.getAttributeNamespace(i), element.getAttributeName(i),
-          element.getAttributeValue(i));
     }
     return (retval);
   }

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -227,7 +227,7 @@ public class BaseFormParserForJavaRosa {
         + xmlWithoutTimestampComment.substring(idx);
   }
 
-  private static synchronized final XFormParser parseFormDefinition(String xml) throws ODKIncompleteSubmissionData {
+  private static synchronized XFormParser parseFormDefinition(String xml) throws ODKIncompleteSubmissionData {
 
     StringReader isr = null;
     try {

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -415,17 +415,7 @@ public class BaseFormParserForJavaRosa {
 
     initializeJavaRosa();
 
-    Document doc = new Document();
-    try (StringReader isr = new StringReader(xml)) {
-      KXmlParser parser = new KXmlParser();
-      parser.setInput(isr);
-      parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
-      doc.parse(parser);
-    } catch (IOException | XmlPullParserException e) {
-      throw new ODKIncompleteSubmissionData(
-          "Javarosa failed to parse the XForm definition. Is this an XForm definition?", e,
-          Reason.BAD_JR_PARSE);
-    }
+    Document doc = parseXmlToDocument(xml);
 
     // Parse any odk:length in bindings
     Element head = getChild(doc.getRootElement(), "head");
@@ -608,6 +598,21 @@ public class BaseFormParserForJavaRosa {
     }
     // clean illegal characters from title
     title = formTitle.replace(BasicConsts.FORWARDSLASH, BasicConsts.EMPTY_STRING);
+  }
+
+  private static Document parseXmlToDocument(String xml) throws ODKIncompleteSubmissionData {
+    try (StringReader isr = new StringReader(xml)) {
+      Document doc = new Document();
+      KXmlParser parser = new KXmlParser();
+      parser.setInput(isr);
+      parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
+      doc.parse(parser);
+      return doc;
+    } catch (IOException | XmlPullParserException e) {
+      throw new ODKIncompleteSubmissionData(
+          "Javarosa failed to parse the XForm definition. Is this an XForm definition?", e,
+          Reason.BAD_JR_PARSE);
+    }
   }
 
   private List<Element> getChildren(Element element, String name) {

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -228,16 +228,11 @@ public class BaseFormParserForJavaRosa {
   }
 
   private static synchronized XFormParser parseFormDefinition(String xml) throws ODKIncompleteSubmissionData {
-
-    StringReader isr = null;
-    try {
-      isr = new StringReader(xml);
+    try (StringReader isr = new StringReader(xml)) {
       Document doc = XFormParser.getXMLDocument(isr);
       return new XFormParser(doc);
     } catch (Exception e) {
       throw new ODKIncompleteSubmissionData(e, Reason.BAD_JR_PARSE);
-    } finally {
-      isr.close();
     }
   }
 

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -17,7 +17,6 @@
 
 package org.opendatakit.aggregate.parser;
 
-import static java.util.stream.Collectors.toList;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORM_ID_ATTRIBUTE_NAME;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH_SUBSTITUTION;
@@ -33,8 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.IDataReference;

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -263,10 +263,6 @@ public class BaseFormParserForJavaRosa {
   // original bindings from parse-time for later comparison
   private final List<Element> bindElements = new ArrayList<Element>();
 
-  private void setNodesetStringLength(String nodeset, Integer length) {
-    stringLengths.put(nodeset, length);
-  }
-
   protected Integer getNodesetStringLength(AbstractTreeElement<?> e) {
     List<String> path = new ArrayList<String>();
     while (e != null && e.getName() != null) {
@@ -419,12 +415,7 @@ public class BaseFormParserForJavaRosa {
 
     List<Element> allBindings = getBindings(doc);
     allBindings.forEach(this::storeCopyOfBinding);
-
-    // Set lengths of fields if odk:length has been defined
-    allBindings.forEach(e -> Optional
-        .ofNullable(e.getAttributeValue(NAMESPACE_ODK, "length"))
-        .map(Integer::valueOf)
-        .ifPresent(length -> setNodesetStringLength(getNodeset(e), length)));
+    allBindings.forEach(this::storeLengthOfBinding);
 
     XFormParser xfp = new XFormParser(doc);
     try {
@@ -593,6 +584,17 @@ public class BaseFormParserForJavaRosa {
     }
     // clean illegal characters from title
     title = formTitle.replace(BasicConsts.FORWARDSLASH, BasicConsts.EMPTY_STRING);
+  }
+
+  /**
+   * Reads an optional <code>odk:length</code> attribute and saves it to be used
+   * to size the corresponding storage field.
+   */
+  private void storeLengthOfBinding(Element binding) {
+    Optional
+        .ofNullable(binding.getAttributeValue(NAMESPACE_ODK, "length"))
+        .map(Integer::valueOf)
+        .ifPresent(length -> stringLengths.put(getNodeset(binding), length));
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -421,7 +421,7 @@ public class BaseFormParserForJavaRosa {
       doc.parse(parser);
     } catch (IOException | XmlPullParserException e) {
       throw new ODKIncompleteSubmissionData(
-          "Javarosa failed parse the XForm definition. Is this an XForm definition?", e,
+          "Javarosa failed to parse the XForm definition. Is this an XForm definition?", e,
           Reason.BAD_JR_PARSE);
     }
 

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -55,6 +55,7 @@ import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 /**
@@ -440,7 +441,7 @@ public class BaseFormParserForJavaRosa {
         .map(Integer::valueOf)
         .ifPresent(length -> setNodesetStringLength(getNodeset(e), length)));
 
-    XFormParser xfp = parseFormDefinition(xml);
+    XFormParser xfp = new XFormParser(doc);
     try {
       rootJavaRosaFormDef = xfp.parse();
     } catch (Exception e) {

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -417,10 +417,8 @@ public class BaseFormParserForJavaRosa {
 
     Document doc = parseXmlToDocument(xml);
 
-    // Parse any odk:length in bindings
-    Element head = getChild(doc.getRootElement(), "head");
-    Element model = getChild(head, "model");
-    List<Element> allBindings = getChildren(model, "bind");
+    List<Element> allBindings = getBindings(doc);
+
 
     // Copy binding for later use
     allBindings.forEach(e -> bindElements.add(copyBindingElement(e)));
@@ -600,6 +598,13 @@ public class BaseFormParserForJavaRosa {
     title = formTitle.replace(BasicConsts.FORWARDSLASH, BasicConsts.EMPTY_STRING);
   }
 
+  private static List<Element> getBindings(Document doc) throws ODKIncompleteSubmissionData {
+    // Parse any odk:length in bindings
+    Element head = getChild(doc.getRootElement(), "head");
+    Element model = getChild(head, "model");
+    return getChildren(model, "bind");
+  }
+
   private static Document parseXmlToDocument(String xml) throws ODKIncompleteSubmissionData {
     try (StringReader isr = new StringReader(xml)) {
       Document doc = new Document();
@@ -615,7 +620,7 @@ public class BaseFormParserForJavaRosa {
     }
   }
 
-  private List<Element> getChildren(Element element, String name) {
+  private static List<Element> getChildren(Element element, String name) {
     List<Element> selectedChildren = new ArrayList<>();
     for (int i = 0, max = element.getChildCount(); i < max; i++)
       if (element.getType(i) == Node.ELEMENT) {
@@ -626,7 +631,7 @@ public class BaseFormParserForJavaRosa {
     return selectedChildren;
   }
 
-  private Element getChild(Element element, String name) throws ODKIncompleteSubmissionData {
+  private static Element getChild(Element element, String name) throws ODKIncompleteSubmissionData {
     for (int i = 0, max = element.getChildCount(); i < max; i++)
       if (element.getType(i) == Node.ELEMENT) {
         Element child = (Element) element.getChild(i);
@@ -636,7 +641,7 @@ public class BaseFormParserForJavaRosa {
     throw new ODKIncompleteSubmissionData("Missing " + name + " child element in " + element.getName(), Reason.BAD_JR_PARSE);
   }
 
-  private String getCleanName(Element child) {
+  private static String getCleanName(Element child) {
     String name = child.getName();
     return name.contains(":") ? name.substring(name.indexOf(":") + 1) : name;
   }

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -417,14 +417,7 @@ public class BaseFormParserForJavaRosa {
     allBindings.forEach(this::storeCopyOfBinding);
     allBindings.forEach(this::storeLengthOfBinding);
 
-    XFormParser xfp = new XFormParser(doc);
-    try {
-      rootJavaRosaFormDef = xfp.parse();
-    } catch (Exception e) {
-      throw new ODKIncompleteSubmissionData(
-          "Javarosa failed to construct a FormDef. Is this an XForm definition?", e,
-          Reason.BAD_JR_PARSE);
-    }
+    rootJavaRosaFormDef = parseDocumentIntoFormDef(doc);
 
     if (rootJavaRosaFormDef == null) {
       throw new ODKIncompleteSubmissionData(
@@ -584,6 +577,16 @@ public class BaseFormParserForJavaRosa {
     }
     // clean illegal characters from title
     title = formTitle.replace(BasicConsts.FORWARDSLASH, BasicConsts.EMPTY_STRING);
+  }
+
+  private static FormDef parseDocumentIntoFormDef(Document doc) throws ODKIncompleteSubmissionData {
+    try {
+      return new XFormParser(doc).parse();
+    } catch (Exception e) {
+      throw new ODKIncompleteSubmissionData(
+          "Javarosa failed to construct a FormDef. Is this an XForm definition?", e,
+          Reason.BAD_JR_PARSE);
+    }
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -230,8 +230,7 @@ public class BaseFormParserForJavaRosa {
         + xmlWithoutTimestampComment.substring(idx);
   }
 
-  private static synchronized final XFormParser parseFormDefinition(String xml,
-                                                                    BaseFormParserForJavaRosa parser) throws ODKIncompleteSubmissionData {
+  private static synchronized final XFormParser parseFormDefinition(String xml) throws ODKIncompleteSubmissionData {
 
     StringReader isr = null;
     try {
@@ -448,7 +447,7 @@ public class BaseFormParserForJavaRosa {
         .map(Integer::valueOf)
         .ifPresent(length -> setNodesetStringLength(getNodeset(e), length)));
 
-    XFormParser xfp = parseFormDefinition(xml, this);
+    XFormParser xfp = parseFormDefinition(xml);
     try {
       rootJavaRosaFormDef = xfp.parse();
     } catch (Exception e) {
@@ -583,7 +582,7 @@ public class BaseFormParserForJavaRosa {
       // encrypted -- use the encrypted form template (above) to define
       // the
       // storage for this form.
-      XFormParser exfp = parseFormDefinition(ENCRYPTED_FORM_DEFINITION, this);
+      XFormParser exfp = parseFormDefinition(ENCRYPTED_FORM_DEFINITION);
       try {
         formDef = exfp.parse();
       } catch (IOException e) {


### PR DESCRIPTION
Closes #255 

#### What has been done to verify that this works as intended?
Uploaded a form and then uploaded the same form with its version changed. 
Verified that the new form gets stored in Aggregate.

#### Why is this the best possible solution? Were any other approaches considered?
Although it's not pretty to parse each XML doc twice, we have no other alternative (yet) because once JR returns a FormDef is too late already and we can't rely on extending the parser as on previous versions of JR.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
I used this one for my tests: [simple-form.xml.txt](https://github.com/opendatakit/aggregate/files/2095418/simple-form.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.