### PR TITLE
Issue 265 fix for free google accounts

### DIFF
--- a/installer/ear.zip
+++ b/installer/ear.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bc7637cd73f665898b5f9e969790a5ea50e64e02ed23117e208c3020e91083c
-size 4421
+oid sha256:a4f097fb6d882f19f080828993b10d37edf3c43cd90b25ae253197fc0bc9d4f1
+size 4460

--- a/src/main/gae_ear/background/WEB-INF/appengine-web.xml
+++ b/src/main/gae_ear/background/WEB-INF/appengine-web.xml
@@ -29,4 +29,6 @@
     <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
     <property name="com.google.gdata.DisableCookieHandler" value="true"/>
   </system-properties>
+
+  <url-stream-handler>urlfetch</url-stream-handler>
 </appengine-web-app>

--- a/src/main/gae_ear/background/WEB-INF/appengine-web.xml
+++ b/src/main/gae_ear/background/WEB-INF/appengine-web.xml
@@ -10,17 +10,20 @@
 
   <!--  use sessions and don't require that they commit to the backing store -->
   <sessions-enabled>true</sessions-enabled>
-  <!--  Make GAE more like Tomcat w.r.t. threading... -->
+
+  <!-- Allows App Engine to send multiple requests to one instance in parallel: -->
   <threadsafe>true</threadsafe>
 
   <basic-scaling>
     <max-instances>5</max-instances>
   </basic-scaling>
+
   <!--  Configure static error handlers -->
   <static-error-handlers>
     <handler file="service-error.html"/>
     <handler file="over-quota.html" error-code="over_quota"/>
   </static-error-handlers>
+
   <!-- Configure java.util.logging -->
   <system-properties>
     <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/src/main/gae_ear/background/WEB-INF/appengine-web.xml
+++ b/src/main/gae_ear/background/WEB-INF/appengine-web.xml
@@ -3,27 +3,27 @@
   <application>test</application>
   <module>background</module>
   <version>1</version>
-	<runtime>java8</runtime>
+  <runtime>java8</runtime>
   <use-google-connector-j>false</use-google-connector-j>
 
-	<instance-class>B2</instance-class>
-	
-	<!--  use sessions and don't require that they commit to the backing store -->
-	<sessions-enabled>true</sessions-enabled>
-	<!--  Make GAE more like Tomcat w.r.t. threading... -->
-	<threadsafe>true</threadsafe>
-	
-	<basic-scaling>
-		<max-instances>5</max-instances>
-	</basic-scaling>
-	<!--  Configure static error handlers -->
-	<static-error-handlers>
-		<handler file="service-error.html"/>
-		<handler file="over-quota.html" error-code="over_quota"/>
-	</static-error-handlers>
-	<!-- Configure java.util.logging -->
-	<system-properties>
-		<property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
-		<property name="com.google.gdata.DisableCookieHandler" value="true"/>
-	</system-properties>
+  <instance-class>B2</instance-class>
+
+  <!--  use sessions and don't require that they commit to the backing store -->
+  <sessions-enabled>true</sessions-enabled>
+  <!--  Make GAE more like Tomcat w.r.t. threading... -->
+  <threadsafe>true</threadsafe>
+
+  <basic-scaling>
+    <max-instances>5</max-instances>
+  </basic-scaling>
+  <!--  Configure static error handlers -->
+  <static-error-handlers>
+    <handler file="service-error.html"/>
+    <handler file="over-quota.html" error-code="over_quota"/>
+  </static-error-handlers>
+  <!-- Configure java.util.logging -->
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+    <property name="com.google.gdata.DisableCookieHandler" value="true"/>
+  </system-properties>
 </appengine-web-app>

--- a/src/main/gae_ear/default/WEB-INF/appengine-web.xml
+++ b/src/main/gae_ear/default/WEB-INF/appengine-web.xml
@@ -3,32 +3,32 @@
   <application>test</application>
   <module>default</module>
   <version>1</version>
-	<runtime>java8</runtime>
+  <runtime>java8</runtime>
   <use-google-connector-j>false</use-google-connector-j>
-  
-  	<instance-class>F2</instance-class>
 
-	<!--  use sessions and don't require that they commit to the backing store -->
-	<sessions-enabled>true</sessions-enabled>
+  <instance-class>F2</instance-class>
 
-    <!-- Allows App Engine to send multiple requests to one instance in parallel: -->
-    <threadsafe>true</threadsafe>
-			
-	<automatic-scaling>
-		<max-concurrent-requests>100</max-concurrent-requests>
-		<!-- Increase latency trigger for new instance. We take about 15 seconds to spin up -->
-		<max-pending-latency>14s</max-pending-latency>
-	</automatic-scaling>
+  <!--  use sessions and don't require that they commit to the backing store -->
+  <sessions-enabled>true</sessions-enabled>
 
-	<!--  Configure static error handlers -->
-	<static-error-handlers>
-		<handler file="service-error.html"/>
-		<handler file="over-quota.html" error-code="over_quota"/>
-	</static-error-handlers>
-	
-	<!-- Configure java.util.logging -->
-	<system-properties>
-		<property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
-		<property name="com.google.gdata.DisableCookieHandler" value="true"/>
-	</system-properties>
+  <!-- Allows App Engine to send multiple requests to one instance in parallel: -->
+  <threadsafe>true</threadsafe>
+
+  <automatic-scaling>
+    <max-concurrent-requests>100</max-concurrent-requests>
+    <!-- Increase latency trigger for new instance. We take about 15 seconds to spin up -->
+    <max-pending-latency>14s</max-pending-latency>
+  </automatic-scaling>
+
+  <!--  Configure static error handlers -->
+  <static-error-handlers>
+    <handler file="service-error.html"/>
+    <handler file="over-quota.html" error-code="over_quota"/>
+  </static-error-handlers>
+
+  <!-- Configure java.util.logging -->
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+    <property name="com.google.gdata.DisableCookieHandler" value="true"/>
+  </system-properties>
 </appengine-web-app>

--- a/src/main/gae_ear/default/WEB-INF/appengine-web.xml
+++ b/src/main/gae_ear/default/WEB-INF/appengine-web.xml
@@ -31,4 +31,6 @@
     <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
     <property name="com.google.gdata.DisableCookieHandler" value="true"/>
   </system-properties>
+
+  <url-stream-handler>urlfetch</url-stream-handler>
 </appengine-web-app>


### PR DESCRIPTION
Closes #265 

We were experiencing an issue described [here](https://cloud.google.com/appengine/docs/standard/java/config/appref#url-stream-handler) after updating the engine to Java8

#### What has been done to verify that this works as intended?
Updated a failing instance with this PR's version and verified that now it can publish again.

#### Why is this the best possible solution? Were any other approaches considered?
Conf changed according to official docs

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope, although we have created [docs issue #753](https://github.com/opendatakit/docs/issues/753) to update installation instructions