### PR TITLE
Issue 266 Fix the way we construct the nodeset definition of a binding

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -597,7 +597,7 @@ public class BaseFormParserForJavaRosa {
     Optional
         .ofNullable(binding.getAttributeValue(NAMESPACE_ODK, "length"))
         .map(Integer::valueOf)
-        .ifPresent(length -> stringLengths.put(getNodeset(binding), length));
+        .ifPresent(length -> stringLengths.put(binding.getAttributeValue(null, "nodeset"), length));
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -664,10 +664,10 @@ public class BaseFormParserForJavaRosa {
 
   private String getNodeset(Element e) {
     String nodeset = e.getName();
-    Element current = (Element) e.getParent();
-    while (current != null && current.getName() != null) {
-      nodeset = current.getName() + "/" + nodeset;
-      current = (Element) current.getParent();
+    Object current = e.getParent();
+    while (current instanceof Element && ((Element) current).getName() != null) {
+      nodeset = ((Element)current).getName() + "/" + nodeset;
+      current = ((Element)current).getParent();
     }
     return "/" + nodeset;
   }


### PR DESCRIPTION
Closes #266

This PR fixes a bug introduced in #256 by avoiding to interact over the root Document object, which would produce a class cast exception behind the reported issue

#### What has been done to verify that this works as intended?
Uploaded the form attached to the issue without errors.

#### Why is this the best possible solution? Were any other approaches considered?
It's a narrow fix. It's kind of ugly, mainly because `Element.getParent()` can return another `Element` or the root `Document`, which makes everything harder. Using the parent `Node` class won't help either because it doesn't have everything we need. `Node` works well while inspecting descendants but is quite limited for inspecting ancestors.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
[the one in the issue](https://github.com/opendatakit/aggregate/files/2137652/odk_length.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.