### PR TITLE
Issue 264 Use new version of GAE updater

### DIFF
--- a/installer/gae.zip
+++ b/installer/gae.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2c28bbc689c4b888e4780e4ea8b5ebe975f2829b9bfdcd8041e4594c0238e05
-size 1396896
+oid sha256:3660fda0508aa44ae3ef9411b5e021a0aebfe74a7a0e4dee2e42e6ab1c29cae0
+size 1397392


### PR DESCRIPTION
Closes #264

This PR updates the JAR of the GAE updater used by the installer.

The new updater JAR is 40px wider on Linux hosts.

#### What has been done to verify that this works as intended?
Launch the updater on Ubuntu and verify that now the button doesn't get cropped.

#### Why is this the best possible solution? Were any other approaches considered?
It's a straightforward change that only affects linux hosts.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.