### PR TITLE
Open JSON server links in a new tab

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/table/PublishTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/PublishTable.java
@@ -97,7 +97,7 @@ public class PublishTable extends FlexTable {
       this.setText(i + STARTING_ROW, TYPE, e.getExternalServiceType().getDisplayText());
       this.setWidget(i + STARTING_ROW, OWNERSHIP, new HTML(new SafeHtmlBuilder().appendEscaped(e.getOwnership()).toSafeHtml()));
       HTML link = e.getExternalServiceType() == JSON_SERVER
-          ? new HTML(new SafeHtmlBuilder().appendHtmlConstant("<a href=\"" + e.getName() + "\">").appendEscaped(e.getName()).appendHtmlConstant("</a>").toSafeHtml())
+          ? new HTML(new SafeHtmlBuilder().appendHtmlConstant("<a target=\"_blank\" href=\"" + e.getName() + "\">").appendEscaped(e.getName()).appendHtmlConstant("</a>").toSafeHtml())
           : new HTML(new SafeHtmlBuilder().appendHtmlConstant(e.getName()).toSafeHtml());
       this.setWidget(i + STARTING_ROW, NAME, link);
       this.setWidget(i + STARTING_ROW, DELETE, new DeletePublishButton(e));


### PR DESCRIPTION
Closes #281 

#### What has been done to verify that this works as intended?
Created a new publisher and verified that clicking on the link opens a new tab

#### Why is this the best possible solution? Were any other approaches considered?
It's a straightforward change that adds `target="_blank"` to the link

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.