### PR TITLE
Issue 232 Add Packer build instructions doc

### DIFF
--- a/docs/vm-generation.md
+++ b/docs/vm-generation.md
@@ -8,19 +8,11 @@ The Gradle task `packerBuild` will produce an OVA file with:
 
 ## How to build the VM
 
-- Configure the correct Packer binary package by editing the `gradle.properties` file at the root of the project
-
-  Create it if it doesn't exist by copying the `gradle.properties.example` in its place.
-  
-  Set the value of the `packerZip` property according to your host's operating system. **Use version 1.2.1 or greater**
-  
-  The list of binary packages is available at https://releases.hashicorp.com/packer
-  
-  Example for Linux hosts: `packerZip=https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip`   
+- Configure the correct Packer binary package by editing the `gradle.properties` file at the root of the project. If it doesn't exist, create it by copying the `gradle.properties.example` in its place.
+- Set the value of the `packerZip` property according to your host's operating system. The list of binary packages is available at https://releases.hashicorp.com/packer. **Use version 1.2.1 or greater**. 
+  - Example for Linux hosts: `packerZip=https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip`   
     
-- Build the VM with `./gradlew clean build packerBuild -xtest -PwarMode=complete`
-
-- The VM OVA will be created in the `build/packer/build` directory.
+- Build the VM with `./gradlew clean build packerBuild -xtest -PwarMode=complete`. The VM OVA will be created in the `build/packer/build` directory.
 
 ## VM Networking
 
@@ -41,8 +33,5 @@ The VM is configured to use a NAT network device by default and will make the fo
 
 ## Network configuration
 
-- If you need to change the network configuration, log into your Aggregate VM using a terminal and run `aggregate-config`
-
-  This is a tool that lets you configure your VM to use different FQDN and ports.
-  
-  You can run the tool without arguments to get a help message.
+- If you need to change the network configuration, log into your Aggregate VM using a terminal and run `aggregate-config`. 
+  - This is a tool that lets you configure your VM to use different FQDN and ports. You can run the tool without arguments to get a help message.

--- a/docs/vm-generation.md
+++ b/docs/vm-generation.md
@@ -1,0 +1,48 @@
+# ODK Aggregate Virtual Machine generation
+
+The Gradle task `packerBuild` will produce an OVA file with:
+
+- Tomcat 8.0
+- PostgreSQL 9.6
+- ODK Aggregate deployed as ROOT webapp
+
+## How to build the VM
+
+- Configure the correct Packer binary package by editing the `gradle.properties` file at the root of the project
+
+  Create it if it doesn't exist by copying the `gradle.properties.example` in its place.
+  
+  Set the value of the `packerZip` property according to your host's operating system. **Use version 1.2.1 or greater**
+  
+  The list of binary packages is available at https://releases.hashicorp.com/packer
+  
+  Example for Linux hosts: `packerZip=https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip`   
+    
+- Build the VM with `./gradlew clean build packerBuild -xtest -PwarMode=complete`
+
+- The VM OVA will be created in the `build/packer/build` directory.
+
+## VM Networking
+
+The VM is configured to use a NAT network device by default and will make the following services accessible:
+
+| Service | Host port | Guest port |
+| --- | --- | --- |
+| HTTP | 10080 | 80 |
+| HTTPS | 10443 | 443 |
+
+# Advanced topics
+
+## Root password
+
+- The default password for the `root` user is `aggregate`
+
+- You will be asked to change the password for the `root` user after the first login.
+
+## Network configuration
+
+- If you need to change the network configuration, log into your Aggregate VM using a terminal and run `aggregate-config`
+
+  This is a tool that lets you configure your VM to use different FQDN and ports.
+  
+  You can run the tool without arguments to get a help message.

--- a/docs/vm-generation.md
+++ b/docs/vm-generation.md
@@ -27,9 +27,7 @@ The VM is configured to use a NAT network device by default and will make the fo
 
 ## Root password
 
-- The default password for the `root` user is `aggregate`
-
-- You will be asked to change the password for the `root` user after the first login.
+- The default password for the `root` user is `aggregate`. You will be asked to change the password for the `root` user after the first login.
 
 ## Network configuration
 


### PR DESCRIPTION
Closes #232

This PR adds a docs file explaining how to build the VM with Packer using Gradle tasks. It also explains some details about some features of the VM.

#### What has been done to verify that this works as intended?
No code change in this PR

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
N/A

#### Do we need any specific form for testing your changes? If so, please attach one
N/A

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
N/A