### PR TITLE
Issue 293 Aggregate sets a wrong size for encryption fields

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -542,10 +542,24 @@ public class BaseFormParserForJavaRosa {
       isFieldEncryptedForm = (base64EncryptedFieldRsaPublicKey != null);
     } else {
       isFileEncryptedForm = true;
-      // encrypted -- use the encrypted form template (above) to define
-      // the
-      // storage for this form.
+      // When a form is encrypted, we don't use the actual form that the users sends
+      // because the submissions we will get for this form will only have three fields:
+      // - base64EncryptedKey
+      // - base64EncryptedElementSignature
+      // - encryptedXmlFile
+      //
+      // To address this, we will use the form defined in ENCRYPTED_FORM_DEFINITION instead
+      // which follows the structure described above.
+      // This is discussed in https://github.com/opendatakit/aggregate/issues/294
       XFormParser exfp = parseFormDefinition(ENCRYPTED_FORM_DEFINITION);
+      // Reset bind element and string length maps since we won't be using the original
+      // form parsed and processed at the beginning of this constructor.
+      Document encryptedFormDoc = parseXmlToDocument(ENCRYPTED_FORM_DEFINITION);
+      stringLengths.clear();
+      bindElements.clear();
+      List<Element> encryptedFormBindings = getBindings(encryptedFormDoc);
+      encryptedFormBindings.forEach(this::storeCopyOfBinding);
+      encryptedFormBindings.forEach(this::storeLengthOfBinding);
       try {
         formDef = exfp.parse();
       } catch (IOException e) {


### PR DESCRIPTION
Closes #293

This PR changes the upload form process:
- When Aggregate detects that the form is encrypted, it tricks itself into thinking that the user sent the form defined in `BaseFormParserForJavaRosa.ENCRYPTED_FORM_DEFINITION` which defined field sizes of 2048
- This PR fixes this part of the process to take into account those sizing definitions

#### What has been done to verify that this works as intended?
- Uploaded [this form](https://github.com/opendatakit/aggregate/files/2270898/encrypted-form.zip)
 and verified with PostgreSQL that the `BASE64_ENCRYPTED_KEY` and `BASE64_ENCRYPTED_ELEMENT_SIGNATURE` fields have a size of 2048 chars
- Uploaded some submissions with Collect
- Pulled the form with Briefcase
- Exported the form with Briefcase

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest/quickest patch I came up with reusing what we're already doing with non-encrypted forms

#### Are there any risks to merging this code? If so, what are they?
I don't think so. 

#### Do we need any specific form for testing your changes? If so, please attach one
(already attached to the verification section)

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.