### PR TITLE
Use latest minor release in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: circleci/openjdk:latest
+      - image: circleci/openjdk:8-jdk
       - image: circleci/postgres:9.6
         environment:
         - POSTGRES_USER=circleci


### PR DESCRIPTION
Addresses #296

#### What has been done to verify that this works as intended?
Visual inspection.

#### Why is this the best possible solution? Were any other approaches considered?
I like auto-updating to the latest minor release because that's what we expect from our users. It also feels like it gives us early warning of potential problems we'll run into when we upgrade to a major release.