### PR TITLE
Debian puts latest release in release, so we must use archive instead

### DIFF
--- a/packer/aggregate.json
+++ b/packer/aggregate.json
@@ -218,7 +218,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "debian-9.4.0-amd64-netinst.iso",
     "memory": "1024",
-    "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
     "mirror_directory": "9.4.0/amd64/iso-cd",
     "name": "aggregate",
     "networking": "bridged",


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Tried a packer build and made sure it went to completion

#### Why is this the best possible solution? Were any other approaches considered?
This is for a hotfix and it only affects the packer build.

#### Are there any risks to merging this code? If so, what are they?
Nope. Checksums all match!
