### PR TITLE
Tidy up

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -414,7 +414,11 @@ public class BaseFormParserForJavaRosa {
     Document doc = parseXmlToDocument(xml);
 
     List<Element> allBindings = getBindings(doc);
+
+    bindElements.clear();
     allBindings.forEach(this::storeCopyOfBinding);
+
+    stringLengths.clear();
     allBindings.forEach(this::storeLengthOfBinding);
 
     rootJavaRosaFormDef = parseDocumentIntoFormDef(doc);
@@ -555,10 +559,12 @@ public class BaseFormParserForJavaRosa {
       // Reset bind element and string length maps since we won't be using the original
       // form parsed and processed at the beginning of this constructor.
       Document encryptedFormDoc = parseXmlToDocument(ENCRYPTED_FORM_DEFINITION);
-      stringLengths.clear();
-      bindElements.clear();
       List<Element> encryptedFormBindings = getBindings(encryptedFormDoc);
+
+      bindElements.clear();
       encryptedFormBindings.forEach(this::storeCopyOfBinding);
+
+      stringLengths.clear();
       encryptedFormBindings.forEach(this::storeLengthOfBinding);
       try {
         formDef = exfp.parse();

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -629,7 +629,6 @@ public class BaseFormParserForJavaRosa {
   }
 
   private static List<Element> getBindings(Document doc) throws ODKIncompleteSubmissionData {
-    // Parse any odk:length in bindings
     Element head = getChild(doc.getRootElement(), "head");
     Element model = getChild(head, "model");
     return getChildren(model, "bind");


### PR DESCRIPTION
This PR is a follow up on @lognaturel's comment at https://github.com/opendatakit/aggregate/pull/295#pullrequestreview-144519396

#### What has been done to verify that this works as intended?
Uploaded the attached encrypted form and verified in the database that the table fields had the correct size of 2048 chars (almost same process as in #295)

#### Why is this the best possible solution? Were any other approaches considered?
These straightforward changes clarify how the parser deals with field lengths on plain and encrypted forms.

It could be argued that they're really superfluous, but I agree with @lognaturel on that they make the surrounding code more easily understandable.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one
[This one](https://github.com/opendatakit/aggregate/files/2270898/encrypted-form.zip)

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.