### PR TITLE
Security fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def versions = [
     spring        : '4.3.4.RELEASE',
     springSecurity: '4.2.0.RELEASE',
     gwt           : [
-        servlet      : '2.7.0',
+        servlet      : '2.8.2',
         googleMapsV3 : '1.0.1',
         visualization: '1.1.2'
     ],

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -42,6 +42,7 @@ public interface FormAdminService extends RemoteService {
 
   void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   Date purgePublishedData(String uriExternalService, Date earliest) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -57,5 +57,6 @@ public interface FormAdminService extends RemoteService {
 
   ArrayList<MediaFileSummary> getFormMediaFileList(String formId) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
+  @XsrfProtect
   Date purgeSubmissionsData(String formId, Date value) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -18,6 +18,7 @@ package org.opendatakit.aggregate.client.form;
 
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import com.google.gwt.user.server.rpc.XsrfProtect;
 import java.util.ArrayList;
 import java.util.Date;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -43,6 +44,7 @@ public interface FormAdminService extends RemoteService {
 
   Date purgePublishedData(String uriExternalService, Date earliest) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
+  @XsrfProtect
   void deleteForm(String formId) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
   void deleteSubmission(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -16,45 +16,42 @@
 
 package org.opendatakit.aggregate.client.form;
 
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import java.util.ArrayList;
 import java.util.Date;
-
-import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.client.submission.SubmissionUISummary;
 import org.opendatakit.common.persistence.client.exception.DatastoreFailureException;
 import org.opendatakit.common.security.client.exception.AccessDeniedException;
 
-import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
-
 /**
  * These are the APIs available to users with the ROLE_DATA_OWNER privilege.
  * Adding forms, deleting forms, and other forms management are here.
- * 
+ * <p>
  * See FormService for actions that require the lesser ROLE_DATA_VIEWER privilege.
- * 
- * @author wbrunette@gmail.com
  *
- */@RemoteServiceRelativePath("formadminservice")
+ * @author wbrunette@gmail.com
+ */
+@RemoteServiceRelativePath("formadminservice")
 public interface FormAdminService extends RemoteService {
-  
-  void setFormDownloadable(String formId, Boolean downloadable) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  Date purgePublishedData(String uriExternalService, Date earliest) throws  AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException;
-  
-  void deleteForm(String formId) throws  AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException;
-  
-  void deleteSubmission(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, FormNotAvailableException, RequestFailureException;
-  
-  SubmissionUISummary getIncompleteSubmissions(FilterGroup filter) throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException;
-  
-  void markSubmissionAsComplete(String submissionKeyAsString) throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException;
-  
-  ArrayList<MediaFileSummary> getFormMediaFileList(String formId) throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException;
 
-  Date purgeSubmissionsData(String formId, Date value) throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException;
+  void setFormDownloadable(String formId, Boolean downloadable) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  Date purgePublishedData(String uriExternalService, Date earliest) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
+
+  void deleteForm(String formId) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
+
+  void deleteSubmission(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
+
+  SubmissionUISummary getIncompleteSubmissions(FilterGroup filter) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
+
+  void markSubmissionAsComplete(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
+
+  ArrayList<MediaFileSummary> getFormMediaFileList(String formId) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
+
+  Date purgeSubmissionsData(String formId, Date value) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -47,6 +47,7 @@ public interface FormAdminService extends RemoteService {
   @XsrfProtect
   void deleteForm(String formId) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
+  @XsrfProtect
   void deleteSubmission(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
   SubmissionUISummary getIncompleteSubmissions(FilterGroup filter) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmFormDeletePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmFormDeletePopup.java
@@ -16,25 +16,25 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HTML;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
-
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.HTML;
 
 public final class ConfirmFormDeletePopup extends AbstractPopupBase {
 
   private static final String BUTTON_TXT = "<img src=\"images/green_right_arrow.png\" /> Delete Data and Form";
   private static final String TOOLTIP_TXT = "Delete data and form";
   private static final String HELP_BALLOON_TXT = "This will delete the form and all of the contained " +
-        "data.";
+      "data.";
 
   private final String formId;
 
@@ -45,12 +45,12 @@ public final class ConfirmFormDeletePopup extends AbstractPopupBase {
 
     AggregateButton deleteButton = new AggregateButton(BUTTON_TXT, TOOLTIP_TXT, HELP_BALLOON_TXT);
     deleteButton.addClickHandler(new DeleteHandler());
-    
+
     FlexTable layout = new FlexTable();
 
     HTML message = new HTML(new SafeHtmlBuilder()
         .appendEscaped("Delete all data and the form definition for ")
-        .appendHtmlConstant("<b>"+formId+"</b><br/>")
+        .appendHtmlConstant("<b>" + formId + "</b><br/>")
         .appendEscaped("Do you wish to delete all uploaded data and the form definition for this form?")
         .toSafeHtml());
     layout.setWidget(0, 0, message);
@@ -64,26 +64,19 @@ public final class ConfirmFormDeletePopup extends AbstractPopupBase {
 
     @Override
     public void onClick(ClickEvent event) {
-      // OK -- we are to proceed.
-      // Set up the callback object.
-      AsyncCallback<Void> callback = new AsyncCallback<Void>() {
-        @Override
-        public void onFailure(Throwable caught) {
-          AggregateUI.getUI().reportError(caught);
-        }
-
-        @Override
-        public void onSuccess(Void result) {
-          AggregateUI.getUI().clearError();
-          Window.alert("Successfully scheduled this form's deletion.\n"
+      secureRequest(
+          SecureGWT.getFormAdminService(),
+          (rpc, sessionCookie, cb) -> rpc.deleteForm(formId, cb),
+          () -> {
+            AggregateUI.getUI().clearError();
+            Window.alert("Successfully scheduled this form's deletion.\n"
                 + "It may take several minutes to delete all the "
                 + "data submissions\nfor this form -- after which the "
                 + "form definition itself will be deleted.");
-          AggregateUI.getUI().getTimer().refreshNow();
-        }
-      };
-      // Make the call to the form service.
-      SecureGWT.getFormAdminService().deleteForm(formId, callback);
+            AggregateUI.getUI().getTimer().refreshNow();
+          },
+          AggregateUI.getUI()::reportError
+      );
       hide();
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgePopup.java
@@ -16,21 +16,20 @@
 
 package org.opendatakit.aggregate.client.popups;
 
-import com.google.gwt.safehtml.shared.SafeHtml;
-import java.util.Date;
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HTML;
+import java.util.Date;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
-
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.HTML;
 
 public class ConfirmPurgePopup extends AbstractPopupBase {
 
@@ -60,21 +59,12 @@ public class ConfirmPurgePopup extends AbstractPopupBase {
   private class PurgeHandler implements ClickHandler {
     @Override
     public void onClick(ClickEvent event) {
-
-      // OK -- we are to proceed.
-      SecureGWT.getFormAdminService().purgePublishedData(uri, earliest, new AsyncCallback<Date>() {
-
-        @Override
-        public void onFailure(Throwable caught) {
-          AggregateUI.getUI().reportError("Failed purge of published data: ", caught);
-        }
-
-        @Override
-        public void onSuccess(Date result) {
-          Window.alert("Successful commencement of the purge of " + "\nall data published as of "
-              + result.toString());
-        }
-      });
+      secureRequest(
+          SecureGWT.getFormAdminService(),
+          (rpc, sessionCookie, cb) -> rpc.purgePublishedData(uri, earliest, cb),
+          (Date result) -> Window.alert("Successful commencement of the purge of\nall data published as of " + result.toString()),
+          cause -> AggregateUI.getUI().reportError("Failed purge of published data: ", cause)
+      );
       hide();
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
@@ -72,15 +72,12 @@ public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
           SecureGWT.getFormAdminService(),
           (rpc, sessionCookie, cb) -> rpc.purgeSubmissionsData(summary.getId(), earliest, cb),
           (Date result) -> {
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append("Successful commencement of the purge of:\n");
-            stringBuilder.append(summary.getTitle());
-            stringBuilder.append(" [");
-            stringBuilder.append(summary.getId());
-            stringBuilder.append("].\nDeleting all submission data through\n  ");
-            stringBuilder.append(result.toGMTString());
-            stringBuilder.append("\nIncomplete submissions will not be deleted.");
-            Window.alert(stringBuilder.toString());
+            Window.alert("" +
+                "Successful commencement of the purge of:\n" +
+                summary.getTitle() + " [" + summary.getId() + "].\n" +
+                "Deleting all submission data through\n  " +
+                result.toGMTString() + "\n" +
+                "Incomplete submissions will not be deleted.");
           },
           cause -> AggregateUI.getUI().reportError("Failed purge of submission data: ", cause)
       );

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmSubmissionDeletePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmSubmissionDeletePopup.java
@@ -16,16 +16,16 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HTML;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
-
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.HTML;
 
 public final class ConfirmSubmissionDeletePopup extends AbstractPopupBase {
 
@@ -59,21 +59,15 @@ public final class ConfirmSubmissionDeletePopup extends AbstractPopupBase {
 
     @Override
     public void onClick(ClickEvent event) {
-      // Set up the callback object.
-      AsyncCallback<Void> callback = new AsyncCallback<Void>() {
-        @Override
-        public void onFailure(Throwable caught) {
-          AggregateUI.getUI().reportError(caught);
-        }
-
-        @Override
-        public void onSuccess(Void result) {
-          AggregateUI.getUI().clearError();
-          AggregateUI.getUI().getTimer().refreshNow();
-        }
-      };
-      // Make the call to the form service.
-      SecureGWT.getFormAdminService().deleteSubmission(submissionKeyAsString, callback);
+      secureRequest(
+          SecureGWT.getFormAdminService(),
+          (rpc, sessionCookie, cb) -> rpc.deleteSubmission(submissionKeyAsString, cb),
+          () -> {
+            AggregateUI.getUI().clearError();
+            AggregateUI.getUI().getTimer().refreshNow();
+          },
+          AggregateUI.getUI()::reportError
+      );
       hide();
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/security/SecurityUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/client/security/SecurityUtils.java
@@ -1,0 +1,46 @@
+package org.opendatakit.aggregate.client.security;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Cookies;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.rpc.HasRpcToken;
+import com.google.gwt.user.client.rpc.ServiceDefTarget;
+import com.google.gwt.user.client.rpc.XsrfToken;
+import com.google.gwt.user.client.rpc.XsrfTokenService;
+import com.google.gwt.user.client.rpc.XsrfTokenServiceAsync;
+import java.util.function.Consumer;
+import org.opendatakit.aggregate.client.AggregateUI;
+
+public class SecurityUtils {
+  @FunctionalInterface
+  public interface SecureRpcRequest<T> {
+    void apply(T rpc, String sessionCookie, AsyncCallback<Void> callback);
+  }
+
+  public static <T> void secureRequest(T rpc, SecureRpcRequest<T> request, Runnable onSuccess, Consumer<Throwable> onFailure) {
+    XsrfTokenServiceAsync xsrf = GWT.create(XsrfTokenService.class);
+    ((ServiceDefTarget) xsrf).setServiceEntryPoint(GWT.getModuleBaseURL() + "xsrf");
+    xsrf.getNewXsrfToken(new AsyncCallback<XsrfToken>() {
+      @Override
+      public void onFailure(Throwable caught) {
+        AggregateUI.getUI().reportError("Incomplete security update: ", caught);
+      }
+
+      @Override
+      public void onSuccess(XsrfToken result) {
+        ((HasRpcToken) rpc).setRpcToken(result);
+        request.apply(rpc, Cookies.getCookie("JSESSIONID"), new AsyncCallback<Void>() {
+          @Override
+          public void onFailure(Throwable caught) {
+            onFailure.accept(caught);
+          }
+
+          @Override
+          public void onSuccess(Void result) {
+            onSuccess.run();
+          }
+        });
+      }
+    });
+  }
+}

--- a/src/main/java/org/opendatakit/aggregate/client/security/SecurityUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/client/security/SecurityUtils.java
@@ -17,10 +17,27 @@ public class SecurityUtils {
     void apply(T rpc, String sessionCookie, AsyncCallback<U> callback);
   }
 
+  /**
+   * Executes a secure request (with CSRF protection) to make a RPC.
+   * <p>
+   * This overload is used when the RPC call doesn't return anything (Void type)
+   *
+   * @see #secureRequest(Object, SecureRpcRequest, Consumer, Consumer)
+   */
   public static <T> void secureRequest(T rpc, SecureRpcRequest<T, Void> request, Runnable onSuccess, Consumer<Throwable> onFailure) {
     secureRequest(rpc, request, __ -> onSuccess.run(), onFailure);
   }
 
+  /**
+   * Executes a secure request (with CSRF protection) to make a RPC.
+   *
+   * @param rpc       RPC class that will be invoked
+   * @param request   Request that makes the actual RPC call
+   * @param onSuccess Callback to be called on success. It receives the request's output
+   * @param onFailure Callback to be called on failure. It receives the {@link Throwable} cause of the failure
+   * @param <T>       Type of the RPC class
+   * @param <U>       Type of the output of the RPC call
+   */
   public static <T, U> void secureRequest(T rpc, SecureRpcRequest<T, U> request, Consumer<U> onSuccess, Consumer<Throwable> onFailure) {
     XsrfTokenServiceAsync xsrf = GWT.create(XsrfTokenService.class);
     ((ServiceDefTarget) xsrf).setServiceEntryPoint(GWT.getModuleBaseURL() + "xsrf");

--- a/src/main/java/org/opendatakit/aggregate/server/FormAdminServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/FormAdminServiceImpl.java
@@ -16,38 +16,44 @@
 
 package org.opendatakit.aggregate.server;
 
+import static org.opendatakit.aggregate.ContextFactory.getCallingContext;
+import static org.opendatakit.aggregate.constants.BeanDefs.FORM_DELETE_BEAN;
+import static org.opendatakit.aggregate.constants.BeanDefs.PURGE_OLDER_SUBMISSIONS_BEAN;
+import static org.opendatakit.aggregate.constants.ErrorConsts.FORM_DEFINITION_INVALID;
+import static org.opendatakit.aggregate.constants.ErrorConsts.QUOTA_EXCEEDED;
+import static org.opendatakit.aggregate.externalservice.FormServiceCursor.getFormServiceCursor;
+import static org.opendatakit.aggregate.form.FormFactory.retrieveFormByFormId;
+import static org.opendatakit.aggregate.form.MiscTasks.TaskType.DELETE_FORM;
+import static org.opendatakit.aggregate.form.MiscTasks.TaskType.PURGE_OLDER_SUBMISSIONS;
+import static org.opendatakit.aggregate.query.submission.QueryByUIFilterGroup.CompletionFlag.ONLY_INCOMPLETE_SUBMISSIONS;
+import static org.opendatakit.aggregate.task.PurgeOlderSubmissions.PURGE_DATE;
+import static org.opendatakit.common.utils.WebUtils.purgeDateString;
+
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+import com.google.gwt.user.server.rpc.XsrfProtectedServiceServlet;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
-
-import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
+import org.opendatakit.aggregate.client.form.FormAdminService;
 import org.opendatakit.aggregate.client.form.MediaFileSummary;
 import org.opendatakit.aggregate.client.submission.SubmissionUI;
 import org.opendatakit.aggregate.client.submission.SubmissionUISummary;
-import org.opendatakit.aggregate.constants.BeanDefs;
-import org.opendatakit.aggregate.constants.ErrorConsts;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
 import org.opendatakit.aggregate.exception.ODKFormNotFoundException;
 import org.opendatakit.aggregate.externalservice.FormServiceCursor;
-import org.opendatakit.aggregate.form.FormFactory;
 import org.opendatakit.aggregate.form.IForm;
 import org.opendatakit.aggregate.form.MiscTasks;
-import org.opendatakit.aggregate.form.MiscTasks.TaskType;
 import org.opendatakit.aggregate.format.Row;
 import org.opendatakit.aggregate.format.element.ElementFormatter;
 import org.opendatakit.aggregate.format.element.UiElementFormatter;
 import org.opendatakit.aggregate.process.DeleteSubmissions;
 import org.opendatakit.aggregate.query.submission.QueryByUIFilterGroup;
-import org.opendatakit.aggregate.query.submission.QueryByUIFilterGroup.CompletionFlag;
 import org.opendatakit.aggregate.submission.Submission;
 import org.opendatakit.aggregate.submission.SubmissionElement;
 import org.opendatakit.aggregate.submission.SubmissionKey;
@@ -63,29 +69,21 @@ import org.opendatakit.common.persistence.client.exception.DatastoreFailureExcep
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.persistence.exception.ODKEntityNotFoundException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
-import org.opendatakit.common.security.client.exception.AccessDeniedException;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 
-import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+public class FormAdminServiceImpl extends XsrfProtectedServiceServlet implements FormAdminService {
 
-public class FormAdminServiceImpl extends RemoteServiceServlet implements
-    org.opendatakit.aggregate.client.form.FormAdminService {
-
-  /**
-     * 
-     */
   private static final long serialVersionUID = -2513124088714784947L;
 
   @Override
-  public void setFormDownloadable(String formId, Boolean downloadable) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException {
-    HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+  public void setFormDownloadable(String formId, Boolean downloadable) throws RequestFailureException, DatastoreFailureException {
+    HttpServletRequest req = getThreadLocalRequest();
+    CallingContext cc = getCallingContext(this, req);
 
     try {
-      IForm form = FormFactory.retrieveFormByFormId(formId, cc);
+      IForm form = retrieveFormByFormId(formId, cc);
       if (!form.hasValidFormDefinition()) {
-        throw new RequestFailureException(ErrorConsts.FORM_DEFINITION_INVALID); // ill-formed definition
+        throw new RequestFailureException(FORM_DEFINITION_INVALID); // ill-formed definition
       }
       form.setDownloadEnabled(downloadable);
       form.persist(cc);
@@ -94,7 +92,7 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
       throw new FormNotAvailableException(e);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
@@ -102,14 +100,14 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException {
-    HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+  public void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions) throws RequestFailureException, DatastoreFailureException {
+    HttpServletRequest req = getThreadLocalRequest();
+    CallingContext cc = getCallingContext(this, req);
 
     try {
-      IForm form = FormFactory.retrieveFormByFormId(formId, cc);
+      IForm form = retrieveFormByFormId(formId, cc);
       if (!form.hasValidFormDefinition()) {
-        throw new RequestFailureException(ErrorConsts.FORM_DEFINITION_INVALID); // ill-formed definition
+        throw new RequestFailureException(FORM_DEFINITION_INVALID); // ill-formed definition
       }
       form.setSubmissionEnabled(acceptSubmissions);
       form.persist(cc);
@@ -118,55 +116,53 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
       throw new FormNotAvailableException(e);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
     }
   }
 
-  public Date purgePublishedData(String uriExternalService, Date earliest)
-      throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException {
-    HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+  public Date purgePublishedData(String uriExternalService, Date earliest) throws DatastoreFailureException, RequestFailureException {
+    HttpServletRequest req = getThreadLocalRequest();
+    CallingContext cc = getCallingContext(this, req);
 
     FormServiceCursor fsc;
     try {
-      fsc = FormServiceCursor.getFormServiceCursor(uriExternalService, cc);
+      fsc = getFormServiceCursor(uriExternalService, cc);
     } catch (ODKEntityNotFoundException e) {
       e.printStackTrace();
       throw new RequestFailureException("Unable to retrieve publishing configuration");
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
     }
 
     // any confirm parameter value means OK -- purge it!
-    PurgeOlderSubmissions pos = (PurgeOlderSubmissions) cc
-        .getBean(BeanDefs.PURGE_OLDER_SUBMISSIONS_BEAN);
+    PurgeOlderSubmissions pos = (PurgeOlderSubmissions) cc.getBean(PURGE_OLDER_SUBMISSIONS_BEAN);
 
     if (pos == null) {
       throw new RequestFailureException("Unable to configure task to purge submitted data for form " + fsc.getFormId());
     }
     // set up the purge request here...
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
 
-    parameters.put(PurgeOlderSubmissions.PURGE_DATE, WebUtils.purgeDateString(earliest));
+    parameters.put(PURGE_DATE, purgeDateString(earliest));
     IForm form;
     try {
-      form = FormFactory.retrieveFormByFormId(fsc.getFormId(), cc);
+      form = retrieveFormByFormId(fsc.getFormId(), cc);
       if (!form.hasValidFormDefinition()) {
-        throw new RequestFailureException(ErrorConsts.FORM_DEFINITION_INVALID);
+        throw new RequestFailureException(FORM_DEFINITION_INVALID);
       }
     } catch (ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new FormNotAvailableException(e);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
@@ -174,28 +170,24 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
 
     MiscTasks m;
     try {
-      m = new MiscTasks(TaskType.PURGE_OLDER_SUBMISSIONS, form, parameters, cc);
+      m = new MiscTasks(PURGE_OLDER_SUBMISSIONS, form, parameters, cc);
       m.persist(cc);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new RequestFailureException(
           "Unable to establish task to purge submitted data for form " + fsc.getFormId());
     }
-    CallingContext ccDaemon = ContextFactory.getCallingContext(this, req);
+    CallingContext ccDaemon = getCallingContext(this, req);
     ccDaemon.setAsDaemon(true);
     try {
       pos.createPurgeOlderSubmissionsTask(form, m.getSubmissionKey(), 1L, ccDaemon);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
-    } catch (ODKDatastoreException e) {
-      e.printStackTrace();
-      throw new RequestFailureException(
-          "Unable to establish task to purge submitted data for form " + fsc.getFormId());
-    } catch (ODKFormNotFoundException e) {
+      throw new RequestFailureException(QUOTA_EXCEEDED);
+    } catch (ODKDatastoreException | ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new RequestFailureException(
           "Unable to establish task to purge submitted data for form " + fsc.getFormId());
@@ -204,29 +196,29 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public void deleteForm(String formId) throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException {
+  public void deleteForm(String formId) throws DatastoreFailureException, RequestFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+    CallingContext cc = getCallingContext(this, req);
 
     try {
-      FormDelete formDelete = (FormDelete) cc.getBean(BeanDefs.FORM_DELETE_BEAN);
+      FormDelete formDelete = (FormDelete) cc.getBean(FORM_DELETE_BEAN);
       if (formDelete == null) {
         throw new RequestFailureException("Unable to configure task to delete form " + formId);
       }
 
-      IForm formToDelete = FormFactory.retrieveFormByFormId(formId, cc);
+      IForm formToDelete = retrieveFormByFormId(formId, cc);
 
       // If the FormInfo table is the target, log an error!
       if (formToDelete != null) {
-        MiscTasks m = new MiscTasks(TaskType.DELETE_FORM, formToDelete, null, cc);
+        MiscTasks m = new MiscTasks(DELETE_FORM, formToDelete, null, cc);
         m.persist(cc);
-        CallingContext ccDaemon = ContextFactory.getCallingContext(this, req);
+        CallingContext ccDaemon = getCallingContext(this, req);
         ccDaemon.setAsDaemon(true);
         formDelete.createFormDeleteTask(formToDelete, m.getSubmissionKey(), 1L, ccDaemon);
       }
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new FormNotAvailableException(e);
@@ -237,13 +229,13 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public void deleteSubmission(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, FormNotAvailableException, RequestFailureException {
+  public void deleteSubmission(String submissionKeyAsString) throws DatastoreFailureException, RequestFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+    CallingContext cc = getCallingContext(this, req);
 
     // create a list because the submission deleter require a list
     SubmissionKey subKey = new SubmissionKey(submissionKeyAsString);
-    List<SubmissionKey> keyList = new ArrayList<SubmissionKey>();
+    List<SubmissionKey> keyList = new ArrayList<>();
     keyList.add(subKey);
 
     // delete the submission
@@ -252,7 +244,7 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
       deleter.deleteSubmissions(cc);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new FormNotAvailableException(e);
@@ -263,22 +255,20 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public SubmissionUISummary getIncompleteSubmissions(FilterGroup filterGroup)
-      throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException {
+  public SubmissionUISummary getIncompleteSubmissions(FilterGroup filterGroup) throws DatastoreFailureException, RequestFailureException {
 
     HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+    CallingContext cc = getCallingContext(this, req);
 
     try {
       String formId = filterGroup.getFormId();
-      IForm form = FormFactory.retrieveFormByFormId(formId, cc);
+      IForm form = retrieveFormByFormId(formId, cc);
       if (!form.hasValidFormDefinition()) {
-        throw new RequestFailureException(ErrorConsts.FORM_DEFINITION_INVALID);
+        throw new RequestFailureException(FORM_DEFINITION_INVALID);
       }
       SubmissionUISummary summary = new SubmissionUISummary(form.getViewableName());
 
-      QueryByUIFilterGroup query = new QueryByUIFilterGroup(form, filterGroup,
-          CompletionFlag.ONLY_INCOMPLETE_SUBMISSIONS, cc);
+      QueryByUIFilterGroup query = new QueryByUIFilterGroup(form, filterGroup, ONLY_INCOMPLETE_SUBMISSIONS, cc);
       List<Submission> submissions = query.getResultSubmissions(cc);
 
       getSubmissions(filterGroup, cc, summary, form, submissions);
@@ -288,7 +278,7 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
       throw new FormNotAvailableException(e);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
@@ -296,9 +286,7 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
 
   }
 
-  private void getSubmissions(FilterGroup filterGroup, CallingContext cc,
-      SubmissionUISummary summary, IForm form, List<Submission> submissions)
-      throws AccessDeniedException, DatastoreFailureException, RequestFailureException {
+  private void getSubmissions(FilterGroup filterGroup, CallingContext cc, SubmissionUISummary summary, IForm form, List<Submission> submissions) throws DatastoreFailureException, RequestFailureException {
     GenerateHeaderInfo headerGenerator = new GenerateHeaderInfo(filterGroup, summary, form);
     headerGenerator.processForHeaderInfo(form.getTopLevelGroupElement());
 
@@ -309,14 +297,19 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
     // format row elements
     for (Submission sub : submissions) {
       try {
-        Row row = sub.getFormattedValuesAsRow(headerGenerator.includedFormElementNamespaces(),
-          filteredElements, elemFormatter, false, cc);
+        Row row = sub.getFormattedValuesAsRow(
+            headerGenerator.includedFormElementNamespaces(),
+            filteredElements,
+            elemFormatter,
+            false,
+            cc
+        );
 
         SubmissionKey subKey = sub.constructSubmissionKey(form.getTopLevelGroupElement());
         summary.addSubmission(new SubmissionUI(row.getFormattedValues(), subKey.toString()));
       } catch (ODKOverQuotaException e) {
         e.printStackTrace();
-        throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+        throw new RequestFailureException(QUOTA_EXCEEDED);
       } catch (ODKDatastoreException e) {
         e.printStackTrace();
         throw new DatastoreFailureException(e);
@@ -325,9 +318,9 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   private interface VisitorOutcome extends SubmissionVisitor {
-    public boolean getSuccess();
+    boolean getSuccess();
   }
-  
+
   private static final class RemoveIncompleteAttachmentVisitor implements VisitorOutcome {
     final CallingContext cc;
     boolean success = true; // assume it completes successfully...
@@ -356,7 +349,7 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
                 blob.deleteAll(cc);
                 set.removeElementValue(e);
               }
-            } catch ( ODKDatastoreException ex ) {
+            } catch (ODKDatastoreException ex) {
               ex.printStackTrace();
               success = false;
             }
@@ -369,11 +362,11 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   private static final class ModifyIncompleteEncryptedAttachmentVisitor implements VisitorOutcome {
-    
+
     private static final String ENC_EXTENSION = ".enc";
     private static final String MISSING_ENC_EXTENSION = ".missing.enc";
     private static final String MIME_OCTET = "application/octet-stream";
-    
+
     final CallingContext cc;
     boolean success = true; // assume it completes successfully...
 
@@ -397,19 +390,19 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
             BlobSubmissionType blob = (BlobSubmissionType) v;
             try {
               if (blob.getAttachmentCount(cc) == 1 && blob.getContentHash(1, cc) == null) {
-                
+
                 // we need to entirely delete the entry and re-create it
                 // so that we can change the filename to the suffix ".missing.enc"
                 String unrootedFilename = blob.getUnrootedFilename(1, cc);
-                if ( unrootedFilename != null ) {
-                  if ( unrootedFilename.endsWith(ENC_EXTENSION)) {
-                    unrootedFilename = unrootedFilename.substring(0,unrootedFilename.lastIndexOf(".")) + MISSING_ENC_EXTENSION;
+                if (unrootedFilename != null) {
+                  if (unrootedFilename.endsWith(ENC_EXTENSION)) {
+                    unrootedFilename = unrootedFilename.substring(0, unrootedFilename.lastIndexOf(".")) + MISSING_ENC_EXTENSION;
                   }
                 }
                 blob.deleteAll(cc);
                 blob.setValueFromByteArray(new byte[]{}, MIME_OCTET, unrootedFilename, true, cc);
               }
-            } catch ( ODKDatastoreException ex ) {
+            } catch (ODKDatastoreException ex) {
               ex.printStackTrace();
               success = false;
             }
@@ -422,28 +415,27 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public void markSubmissionAsComplete(String submissionKeyAsString)
-      throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException {
+  public void markSubmissionAsComplete(String submissionKeyAsString) throws DatastoreFailureException, RequestFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+    CallingContext cc = getCallingContext(this, req);
 
     // create a list because the submission deleter require a list
     SubmissionKey submissionKey = new SubmissionKey(submissionKeyAsString);
     try {
       List<SubmissionKeyPart> parts = submissionKey.splitSubmissionKey();
       Submission sub = Submission.fetchSubmission(parts, cc);
-      if ( sub == null ) {
+      if (sub == null) {
         throw new RequestFailureException("Unable to revise submission (see logs)");
       }
-      
-      IForm form = FormFactory.retrieveFormByFormId(parts.get(0).getElementName(), cc);
-      if ( !form.hasValidFormDefinition() ) {
+
+      IForm form = retrieveFormByFormId(parts.get(0).getElementName(), cc);
+      if (!form.hasValidFormDefinition()) {
         // should never happen here -- should happen in the fetchSubmission() call above.
         throw new IllegalArgumentException("Form definition is ill-formed"); // ill-formed definition
       }
-      
-      VisitorOutcome visitor = null;
-      if ( !form.isEncryptedForm() ) {
+
+      VisitorOutcome visitor;
+      if (!form.isEncryptedForm()) {
         visitor = new RemoveIncompleteAttachmentVisitor(cc);
       } else {
         visitor = new ModifyIncompleteEncryptedAttachmentVisitor(cc);
@@ -467,7 +459,7 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
       throw new RequestFailureException("Entity not found");
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
@@ -475,38 +467,35 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public ArrayList<MediaFileSummary> getFormMediaFileList(String formId)
-      throws AccessDeniedException, FormNotAvailableException, DatastoreFailureException, RequestFailureException {
+  public ArrayList<MediaFileSummary> getFormMediaFileList(String formId) throws DatastoreFailureException, RequestFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
+    CallingContext cc = getCallingContext(this, req);
 
-    ArrayList<MediaFileSummary> mediaSummaryList = new ArrayList<MediaFileSummary>();
+    ArrayList<MediaFileSummary> mediaSummaryList = new ArrayList<>();
 
     try {
-      IForm form = FormFactory.retrieveFormByFormId(formId, cc);
+      IForm form = retrieveFormByFormId(formId, cc);
       if (!form.hasValidFormDefinition())
         return mediaSummaryList; // ill-formed definition -- still show it...
 
       BinaryContentManipulator bcm = form.getManifestFileset();
       for (int i = 0; i < bcm.getAttachmentCount(cc); ++i) {
-        MediaFileSummary mfs = new MediaFileSummary(bcm.getUnrootedFilename(i + 1, cc),
-            bcm.getContentType(i + 1, cc), bcm.getContentLength(i + 1, cc));
+        MediaFileSummary mfs = new MediaFileSummary(
+            bcm.getUnrootedFilename(i + 1, cc),
+            bcm.getContentType(i + 1, cc),
+            bcm.getContentLength(i + 1, cc)
+        );
         mediaSummaryList.add(mfs);
       }
-      
-      Collections.sort(mediaSummaryList, new Comparator<MediaFileSummary>() {
 
-        @Override
-        public int compare(MediaFileSummary o1, MediaFileSummary o2) {
-          return o1.getFilename().compareToIgnoreCase(o2.getFilename());
-        }});
-      
+      mediaSummaryList.sort((o1, o2) -> o1.getFilename().compareToIgnoreCase(o2.getFilename()));
+
     } catch (ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new FormNotAvailableException(e);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
@@ -515,64 +504,58 @@ public class FormAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public Date purgeSubmissionsData(String formId, Date value) throws AccessDeniedException,
-      FormNotAvailableException, DatastoreFailureException, RequestFailureException {
+  public Date purgeSubmissionsData(String formId, Date value) throws DatastoreFailureException, RequestFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
-    
-    IForm form = null;
+    CallingContext cc = getCallingContext(this, req);
+
+    IForm form;
     try {
-      form = FormFactory.retrieveFormByFormId(formId, cc);
+      form = retrieveFormByFormId(formId, cc);
       if (!form.hasValidFormDefinition()) {
-        throw new RequestFailureException(ErrorConsts.FORM_DEFINITION_INVALID);
+        throw new RequestFailureException(FORM_DEFINITION_INVALID);
       }
     } catch (ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new FormNotAvailableException(e);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new DatastoreFailureException(e);
     }
 
     // any confirm parameter value means OK -- purge it!
-    PurgeOlderSubmissions pos = (PurgeOlderSubmissions) cc
-        .getBean(BeanDefs.PURGE_OLDER_SUBMISSIONS_BEAN);
+    PurgeOlderSubmissions pos = (PurgeOlderSubmissions) cc.getBean(PURGE_OLDER_SUBMISSIONS_BEAN);
 
     if (pos == null) {
       throw new RequestFailureException("Unable to configure task to purge submitted data for form " + formId);
     }
     // set up the purge request here...
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
 
-    parameters.put(PurgeOlderSubmissions.PURGE_DATE, WebUtils.purgeDateString(value));
+    parameters.put(PURGE_DATE, purgeDateString(value));
 
     MiscTasks m;
     try {
-      m = new MiscTasks(TaskType.PURGE_OLDER_SUBMISSIONS, form, parameters, cc);
+      m = new MiscTasks(PURGE_OLDER_SUBMISSIONS, form, parameters, cc);
       m.persist(cc);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
+      throw new RequestFailureException(QUOTA_EXCEEDED);
     } catch (ODKDatastoreException e) {
       e.printStackTrace();
       throw new RequestFailureException(
           "Unable to establish task to purge submitted data for form " + formId);
     }
-    CallingContext ccDaemon = ContextFactory.getCallingContext(this, req);
+    CallingContext ccDaemon = getCallingContext(this, req);
     ccDaemon.setAsDaemon(true);
     try {
       pos.createPurgeOlderSubmissionsTask(form, m.getSubmissionKey(), 1L, ccDaemon);
     } catch (ODKOverQuotaException e) {
       e.printStackTrace();
-      throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
-    } catch (ODKDatastoreException e) {
-      e.printStackTrace();
-      throw new RequestFailureException(
-          "Unable to establish task to purge submitted data for form " + formId);
-    } catch (ODKFormNotFoundException e) {
+      throw new RequestFailureException(QUOTA_EXCEEDED);
+    } catch (ODKDatastoreException | ODKFormNotFoundException e) {
       e.printStackTrace();
       throw new RequestFailureException(
           "Unable to establish task to purge submitted data for form " + formId);

--- a/src/main/java/org/opendatakit/common/security/client/security/admin/SecurityAdminService.java
+++ b/src/main/java/org/opendatakit/common/security/client/security/admin/SecurityAdminService.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.common.security.client.security.admin;
 
+import com.google.gwt.user.server.rpc.XsrfProtect;
 import java.util.ArrayList;
 
 import org.opendatakit.common.persistence.client.exception.DatastoreFailureException;
@@ -45,6 +46,7 @@ public interface SecurityAdminService extends RemoteService {
      * @throws DatastoreFailureException
      */
     ArrayList<UserSecurityInfo> getAllUsers(boolean withAuthorities) throws AccessDeniedException, DatastoreFailureException;
-    
+
+    @XsrfProtect
     void setUsersAndGrantedAuthorities( String xsrfString, ArrayList<UserSecurityInfo> users, ArrayList<GrantedAuthorityName> allGroups ) throws AccessDeniedException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/common/security/server/SecurityAdminServiceImpl.java
+++ b/src/main/java/org/opendatakit/common/security/server/SecurityAdminServiceImpl.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.common.security.server;
 
+import com.google.gwt.user.server.rpc.XsrfProtectedServiceServlet;
 import java.util.ArrayList;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,7 +36,7 @@ import com.google.gwt.user.server.rpc.RemoteServiceServlet;
  * @author mitchellsundt@gmail.com
  *
  */
-public class SecurityAdminServiceImpl extends RemoteServiceServlet implements
+public class SecurityAdminServiceImpl extends XsrfProtectedServiceServlet implements
 org.opendatakit.common.security.client.security.admin.SecurityAdminService {
 
     /**

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -69,6 +69,24 @@
         <url-pattern>/odktables/*</url-pattern>
     </filter-mapping>
 
+    <!--CSRF PROTECTION-->
+
+    <servlet>
+        <servlet-name>xsrf</servlet-name>
+        <servlet-class>
+            com.google.gwt.user.server.rpc.XsrfTokenServiceServlet
+        </servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>xsrf</servlet-name>
+        <url-pattern>/aggregateui/xsrf</url-pattern>
+    </servlet-mapping>
+
+    <context-param>
+        <param-name>gwt.xsrf.session_cookie_name</param-name>
+        <param-value>JSESSIONID</param-value>
+    </context-param>
+
     <!-- Simple Servlets -->
     <servlet>
         <servlet-name>filterServiceImpl</servlet-name>


### PR DESCRIPTION
This PR adds extra security protections to some RPC calls:
- Change users from Site Admin > Edit Users
- Delete a form
- Delete submission
- Purge published data
- Purge submissions

#### What has been done to verify that this works as intended?
First, I've manually verified that all these operations still work in my local Aggregate instance
Second, I've inspected the network interchange of the delete form action and I've resent it using curl from the command line to verify that it won't work since the CSRF token wasn't valid anymore.

#### Why is this the best possible solution? Were any other approaches considered?
This solution implements the [official instructions](http://www.gwtproject.org/doc/latest/DevGuideSecurityRpcXsrf.html) to add CSRF protection to GWT apps.

To reduce code duplication and complexity, I've created a wrapper that handles client-side CSRF requests.

#### Are there any risks to merging this code? If so, what are they?
Any third party hitting these RPCs will have to request a CSRF token before making them. 

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.