### PR TITLE
Issue 305 add param to include incomplete subs

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
@@ -21,6 +21,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -165,7 +166,11 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
       // are fully uploaded. We snarf everything.
       Query query = cc.getDatastore().createQuery(tbl, "SubmissionDownloadListServlet.doGet", cc.getCurrentUser());
       query.addSort(tbl.lastUpdateDate, Query.Direction.ASCENDING);
-      query.addFilter(tbl.isComplete, FilterOperation.EQUAL, true);
+      boolean includeIncomplete = Optional.ofNullable(getParameter(req, "includeIncomplete"))
+          .map(Boolean::parseBoolean)
+          .orElse(false);
+      if (!includeIncomplete)
+        query.addFilter(tbl.isComplete, FilterOperation.EQUAL, true);
 
       QueryResult result = query.executeQuery(cursor, numEntries);
       List<String> uriList = new ArrayList<String>();

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
@@ -45,6 +45,8 @@ import org.opendatakit.common.utils.WebCursorUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.opendatakit.common.web.constants.HtmlConsts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Servlet to generate the XML list of submission instanceIDs for a given form.
@@ -73,6 +75,7 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  * @author mitchellsundt@gmail.com
  */
 public class SubmissionDownloadListServlet extends ServletUtilBase {
+  private static final Logger log = LoggerFactory.getLogger(SubmissionDownloadListServlet.class);
 
   private static final String ID_FRAGMENT_TAG = "idChunk";
 
@@ -173,6 +176,7 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
               // Optional.map() uses Optional.ofNullable() to wrap the
               // mappers output. Returning null here will make this optional
               // instance to be empty
+              log.warn("Can't parse incoming includeIncomplete query string arg", t);
               return null;
             }
           })

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
@@ -164,7 +164,18 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
       Query query = cc.getDatastore().createQuery(tbl, "SubmissionDownloadListServlet.doGet", cc.getCurrentUser());
       query.addSort(tbl.lastUpdateDate, Query.Direction.ASCENDING);
       boolean includeIncomplete = Optional.ofNullable(getParameter(req, "includeIncomplete"))
-          .map(Boolean::parseBoolean)
+          .map(value -> {
+            // This try block will prevent failures when we get something
+            // that can't be parsed into Boolean
+            try {
+              return Boolean.parseBoolean(value);
+            } catch (Throwable t) {
+              // Optional.map() uses Optional.ofNullable() to wrap the
+              // mappers output. Returning null here will make this optional
+              // instance to be empty
+              return null;
+            }
+          })
           .orElse(false);
       if (!includeIncomplete)
         query.addFilter(tbl.isComplete, FilterOperation.EQUAL, true);

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
@@ -174,7 +174,7 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
               return Boolean.parseBoolean(value);
             } catch (Throwable t) {
               // Optional.map() uses Optional.ofNullable() to wrap the
-              // mappers output. Returning null here will make this optional
+              // mapper's output. Returning null here will make this optional
               // instance to be empty
               log.warn("Can't parse incoming includeIncomplete query string arg", t);
               return null;

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionDownloadListServlet.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2011 University of Washington.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -20,11 +20,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
@@ -71,9 +69,8 @@ import org.opendatakit.common.web.constants.HtmlConsts;
  * <li>lastUpdateDate (ascending) and</li>
  * <li>URI (ascending).</li>
  * </ol>
- * 
+ *
  * @author mitchellsundt@gmail.com
- * 
  */
 public class SubmissionDownloadListServlet extends ServletUtilBase {
 
@@ -101,9 +98,9 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
   /**
    * Handler for HTTP Get request that responds with an XML list of instanceIDs
    * on the system.
-   * 
+   *
    * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
-   *      javax.servlet.http.HttpServletResponse)
+   *     javax.servlet.http.HttpServletResponse)
    */
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -117,10 +114,10 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
       errorMissingKeyParam(resp);
       return;
     }
-    if ( formId.contains(ParserConsts.FORWARD_SLASH) ) {
+    if (formId.contains(ParserConsts.FORWARD_SLASH)) {
       formId = formId.replaceAll(ParserConsts.FORWARD_SLASH, ParserConsts.FORWARD_SLASH_SUBSTITUTION);
     }
-    
+
     // the cursor string
     String websafeCursorString = getParameter(req, ServletConsts.CURSOR);
     QueryResumePoint cursor = WebCursorUtils.parseCursorParameter(websafeCursorString);
@@ -173,7 +170,7 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
         query.addFilter(tbl.isComplete, FilterOperation.EQUAL, true);
 
       QueryResult result = query.executeQuery(cursor, numEntries);
-      List<String> uriList = new ArrayList<String>();
+      List<String> uriList = new ArrayList<>();
       for (CommonFieldsBase cb : result.getResultList()) {
         uriList.add(cb.getUri());
       }
@@ -200,12 +197,12 @@ public class SubmissionDownloadListServlet extends ServletUtilBase {
       }
 
       QueryResumePoint qrp = result.getResumeCursor();
-      if ( qrp == null ) {
+      if (qrp == null) {
         websafeCursorString = null;
       } else {
         websafeCursorString = qrp.asWebsafeCursor();
       }
-      
+
       if (websafeCursorString != null) {
         // emit the cursor value...
         Element eCursorContinue = d.createElement(XML_TAG_NAMESPACE, CURSOR_TAG);


### PR DESCRIPTION
Closes #305

This PR adds an optional argument that can be added when downloading the list of a form's submissions to include incomplete submissions.

The new argument is `includeIncomplete` and accepts any value that can be parsed as `Boolean` i.e. `true`, and `false.

#### What has been done to verify that this works as intended?
- With a form that had 73 submissions:
	- Made 10 submissions incomplete by changing their `_IS_COMPLETE` field in the database
- Used Briefcase (version from PR https://github.com/opendatakit/briefcase/pull/615) to pull the form without the `--include_incomplete` flag. Verified that I got 63 submissions, as expected
- Clean the storage dir and pull again the form, this time adding the `--include_incomplete` flag. Verified that I got 73 submissions, as expected

#### Why is this the best possible solution? Were any other approaches considered?
This is the narrowest change I could come up with. No other approaches considered.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
No. Any form will do.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No. This servlet is used by third-party apps, and it's not designed to be used by final users.