### PR TITLE
Security fixes batch 2

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -17,15 +17,13 @@
 package org.opendatakit.aggregate.client.externalserv;
 
 
-import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.constants.common.BinaryOption;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
 import org.opendatakit.common.persistence.client.exception.DatastoreFailureException;
 import org.opendatakit.common.security.client.exception.AccessDeniedException;
-
-import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
 /**
  * These are the actions requiring the ROLE_DATA_OWNER privilege.  They
@@ -34,26 +32,25 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
  *
  * @author mitchellsundt@gmail.com
  * @author wbrunette@gmail.com
- *
  */
 @RemoteServiceRelativePath("servicesadminservice")
 public interface ServicesAdminService extends RemoteService {
 
-  ExternServSummary [] getExternalServices(String formid) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  ExternServSummary[] getExternalServices(String formid) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  String createFusionTable(String formId, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  String createGoogleSpreadsheet(String formId, String name, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  String createFusionTable(String formId, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  String createSimpleJsonServer(String formId, String authKey, String url, ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  String createGoogleSpreadsheet(String formId, String name, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  String createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp, String user, String hashedPassword, String url, ExternalServicePublicationOption es, String ownerEmail) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  String createSimpleJsonServer(String formId, String authKey, String url, ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  String createRedCapServer(String formId, String apiKey, String url, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  String createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp, String user, String hashedPassword, String url, ExternalServicePublicationOption es, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  Boolean deletePublisher(String uri) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  String createRedCapServer(String formId, String apiKey, String url, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  void restartPublisher(String uri) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  Boolean deletePublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
-  void updateApiKeyAndRestartPublisher(String uri, String apiKey) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  void restartPublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  void updateApiKeyAndRestartPublisher(String uri, String apiKey) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -42,6 +42,7 @@ public interface ServicesAdminService extends RemoteService {
   @XsrfProtect
   String createFusionTable(String formId, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   String createGoogleSpreadsheet(String formId, String name, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   String createSimpleJsonServer(String formId, String authKey, String url, ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -49,6 +49,7 @@ public interface ServicesAdminService extends RemoteService {
 
   String createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp, String user, String hashedPassword, String url, ExternalServicePublicationOption es, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   String createRedCapServer(String formId, String apiKey, String url, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   Boolean deletePublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -19,6 +19,7 @@ package org.opendatakit.aggregate.client.externalserv;
 
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import com.google.gwt.user.server.rpc.XsrfProtect;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.constants.common.BinaryOption;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
@@ -38,6 +39,7 @@ public interface ServicesAdminService extends RemoteService {
 
   ExternServSummary[] getExternalServices(String formid) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   String createFusionTable(String formId, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   String createGoogleSpreadsheet(String formId, String name, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -45,6 +45,7 @@ public interface ServicesAdminService extends RemoteService {
   @XsrfProtect
   String createGoogleSpreadsheet(String formId, String name, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   String createSimpleJsonServer(String formId, String authKey, String url, ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   String createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp, String user, String hashedPassword, String url, ExternalServicePublicationOption es, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -56,6 +56,7 @@ public interface ServicesAdminService extends RemoteService {
 
   Boolean deletePublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void restartPublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -58,5 +58,6 @@ public interface ServicesAdminService extends RemoteService {
 
   void restartPublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void updateApiKeyAndRestartPublisher(String uri, String apiKey) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -48,6 +48,7 @@ public interface ServicesAdminService extends RemoteService {
   @XsrfProtect
   String createSimpleJsonServer(String formId, String authKey, String url, ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   String createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp, String user, String hashedPassword, String url, ExternalServicePublicationOption es, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminServiceAsync.java
@@ -16,31 +16,30 @@
 
 package org.opendatakit.aggregate.client.externalserv;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.opendatakit.aggregate.constants.common.BinaryOption;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
-
-import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public interface ServicesAdminServiceAsync {
 
   void getExternalServices(String formid, AsyncCallback<ExternServSummary[]> callback);
 
   void createFusionTable(String formId, ExternalServicePublicationOption esOption,
-      String ownerEmail, AsyncCallback<String> callback);
+                         String ownerEmail, AsyncCallback<String> callback);
 
   void createGoogleSpreadsheet(String formId, String name,
-      ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
+                               ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
 
   void createSimpleJsonServer(String formId, String authKey, String url,
-      ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption,
-      AsyncCallback<String> callback);
+                              ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption,
+                              AsyncCallback<String> callback);
 
   void createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp,
-      String user, String hashedPassword, String url, ExternalServicePublicationOption es,
-      String ownerEmail, AsyncCallback<String> callback);
+                              String user, String hashedPassword, String url, ExternalServicePublicationOption es,
+                              String ownerEmail, AsyncCallback<String> callback);
 
   void createRedCapServer(String formId, String apiKey, String url,
-      ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
+                          ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
 
   void deletePublisher(String uri, AsyncCallback<Boolean> callback);
 

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
@@ -18,6 +18,7 @@ package org.opendatakit.aggregate.client.form;
 
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import com.google.gwt.user.server.rpc.XsrfProtect;
 import java.util.ArrayList;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
@@ -38,6 +39,7 @@ public interface FormService extends RemoteService {
 
   ArrayList<ExportSummary> getExports() throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   Boolean createCsvFromFilter(FilterGroup group) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   Boolean createJsonFileFromFilter(FilterGroup group) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
@@ -42,6 +42,7 @@ public interface FormService extends RemoteService {
   @XsrfProtect
   Boolean createCsvFromFilter(FilterGroup group) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   Boolean createJsonFileFromFilter(FilterGroup group) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   KmlOptionsSummary getPossibleKmlSettings(String formId) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
@@ -16,41 +16,37 @@
 
 package org.opendatakit.aggregate.client.form;
 
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import java.util.ArrayList;
-
-import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.common.persistence.client.exception.DatastoreFailureException;
 import org.opendatakit.common.security.client.exception.AccessDeniedException;
 
-import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
-
 /**
  * These are the APIs available to users with the ROLE_DATA_VIEWER privilege.
- * Adding forms, deleting forms, and other forms management should be 
+ * Adding forms, deleting forms, and other forms management should be
  * handled in the FormAdminService (which requires ROLE_DATA_OWNER privilege).
- * 
- * @author wbrunette@gmail.com
  *
+ * @author wbrunette@gmail.com
  */
 @RemoteServiceRelativePath("formservice")
 public interface FormService extends RemoteService {
 
   ArrayList<FormSummary> getForms() throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
-  
-  ArrayList<ExportSummary> getExports() throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  Boolean createCsvFromFilter(FilterGroup group) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  Boolean createJsonFileFromFilter(FilterGroup group) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  KmlOptionsSummary getPossibleKmlSettings(String formId) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
 
-  Boolean createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  GeopointElementList getGpsCoordnates(String formId) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
-  
-  void deleteExport(String uri) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException;
+  ArrayList<ExportSummary> getExports() throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  Boolean createCsvFromFilter(FilterGroup group) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  Boolean createJsonFileFromFilter(FilterGroup group) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  KmlOptionsSummary getPossibleKmlSettings(String formId) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  Boolean createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  GeopointElementList getGpsCoordnates(String formId) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
+
+  void deleteExport(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
@@ -47,6 +47,7 @@ public interface FormService extends RemoteService {
 
   KmlOptionsSummary getPossibleKmlSettings(String formId) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   Boolean createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   GeopointElementList getGpsCoordnates(String formId) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormServiceAsync.java
@@ -16,11 +16,9 @@
 
 package org.opendatakit.aggregate.client.form;
 
-import java.util.ArrayList;
-
-import org.opendatakit.aggregate.client.filter.FilterGroup;
-
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.ArrayList;
+import org.opendatakit.aggregate.client.filter.FilterGroup;
 
 public interface FormServiceAsync {
 
@@ -35,7 +33,7 @@ public interface FormServiceAsync {
   void createCsvFromFilter(FilterGroup group, AsyncCallback<Boolean> callback);
 
   void createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude,
-      AsyncCallback<Boolean> callback);
+                           AsyncCallback<Boolean> callback);
 
   void createJsonFileFromFilter(FilterGroup group, AsyncCallback<Boolean> callback);
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
@@ -95,26 +95,6 @@ public final class ExportPopup extends AbstractPopupBase {
     setWidget(optionsBar);
   }
 
-  private class CreateExportCallback implements AsyncCallback<Boolean> {
-
-    @Override
-    public void onFailure(Throwable caught) {
-      AggregateUI.getUI().reportError(caught);
-    }
-
-    @Override
-    public void onSuccess(Boolean result) {
-      if (result) {
-        AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
-      } else {
-        Window.alert(EXPORT_ERROR_MSG);
-      }
-
-      hide();
-    }
-  }
-
-
   private class FiltersCallback implements AsyncCallback<FilterSet> {
 
     private static final String PROBLEM_NULL_FILTER_SET = "PROBLEM: got a NULL for a filterSet from server";
@@ -147,7 +127,7 @@ public final class ExportPopup extends AbstractPopupBase {
       final FilterGroup filterGroup = filtersBox.getSelectedFilter();
 
       if (filterGroup == null) {
-        AggregateUI.getUI().reportError(new Throwable(PROBLEM_NULL_FILTER_GROUP));
+        onFailure(new Throwable(PROBLEM_NULL_FILTER_GROUP));
         return;
       }
 
@@ -155,31 +135,15 @@ public final class ExportPopup extends AbstractPopupBase {
         secureRequest(
             SecureGWT.getFormService(),
             (rpc, sc, cb) -> rpc.createCsvFromFilter(filterGroup, cb),
-            (Boolean result) -> {
-              if (result) {
-                AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
-              } else {
-                Window.alert(EXPORT_ERROR_MSG);
-              }
-
-              hide();
-            },
-            cause -> AggregateUI.getUI().reportError(cause)
+            this::onSuccess,
+            this::onFailure
         );
       } else if (type == ExportType.JSONFILE) {
         secureRequest(
             SecureGWT.getFormService(),
             (rpc, sc, cb) -> rpc.createJsonFileFromFilter(filterGroup, cb),
-            (Boolean result) -> {
-              if (result) {
-                AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
-              } else {
-                Window.alert(EXPORT_ERROR_MSG);
-              }
-
-              hide();
-            },
-            cause -> AggregateUI.getUI().reportError(cause)
+            this::onSuccess,
+            this::onFailure
         );
       } else if (type == ExportType.KML) {
         KmlOptionsPopup popup = new KmlOptionsPopup(formId, filterGroup);
@@ -189,6 +153,20 @@ public final class ExportPopup extends AbstractPopupBase {
         new ErrorDialog().show();
       }
 
+    }
+
+    private void onFailure(Throwable cause) {
+      AggregateUI.getUI().reportError(cause);
+    }
+
+    private void onSuccess(Boolean result) {
+      if (result) {
+        AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
+      } else {
+        Window.alert(EXPORT_ERROR_MSG);
+      }
+
+      hide();
     }
   }
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
@@ -167,7 +167,20 @@ public final class ExportPopup extends AbstractPopupBase {
             cause -> AggregateUI.getUI().reportError(cause)
         );
       } else if (type == ExportType.JSONFILE) {
-        SecureGWT.getFormService().createJsonFileFromFilter(filterGroup, new CreateExportCallback());
+        secureRequest(
+            SecureGWT.getFormService(),
+            (rpc, sc, cb) -> rpc.createJsonFileFromFilter(filterGroup, cb),
+            (Boolean result) -> {
+              if (result) {
+                AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
+              } else {
+                Window.alert(EXPORT_ERROR_MSG);
+              }
+
+              hide();
+            },
+            cause -> AggregateUI.getUI().reportError(cause)
+        );
       } else if (type == ExportType.KML) {
         KmlOptionsPopup popup = new KmlOptionsPopup(formId, filterGroup);
         popup.setPopupPositionAndShow(popup.getPositionCallBack());

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ExportPopup.java
@@ -16,7 +16,15 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.DialogBox;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HTML;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
@@ -27,15 +35,6 @@ import org.opendatakit.aggregate.client.widgets.EnumListBox;
 import org.opendatakit.aggregate.client.widgets.FilterListBox;
 import org.opendatakit.aggregate.constants.common.ExportType;
 import org.opendatakit.aggregate.constants.common.SubTabs;
-
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.DialogBox;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.HTML;
 
 public final class ExportPopup extends AbstractPopupBase {
 
@@ -79,7 +78,7 @@ public final class ExportPopup extends AbstractPopupBase {
 
     fileType = new EnumListBox<ExportType>(ExportType.values(), FILE_TYPE_TOOLTIP,
         FILE_TYPE_BALLOON);
-    
+
     // set the standard header widgets
     optionsBar = new FlexTable();
     optionsBar.addStyleName("stretch_header");
@@ -134,7 +133,9 @@ public final class ExportPopup extends AbstractPopupBase {
       // created filter list
       filtersBox.updateFilterDropDown(filterSet);
     }
-  };
+  }
+
+  ;
 
   private class CreateExportHandler implements ClickHandler {
     @Override
@@ -142,8 +143,8 @@ public final class ExportPopup extends AbstractPopupBase {
       ExportType type = ExportType.valueOf(fileType.getValue(fileType.getSelectedIndex()));
 
       FilterGroup filterGroup = filtersBox.getSelectedFilter();
-      
-      if ( filterGroup == null ) {
+
+      if (filterGroup == null) {
         AggregateUI.getUI().reportError(new Throwable(PROBLEM_NULL_FILTER_GROUP));
         return;
       }
@@ -152,7 +153,7 @@ public final class ExportPopup extends AbstractPopupBase {
         SecureGWT.getFormService().createCsvFromFilter(filterGroup, new CreateExportCallback());
       } else if (type == ExportType.JSONFILE) {
         SecureGWT.getFormService().createJsonFileFromFilter(filterGroup, new CreateExportCallback());
-      } else if( type == ExportType.KML) {
+      } else if (type == ExportType.KML) {
         KmlOptionsPopup popup = new KmlOptionsPopup(formId, filterGroup);
         popup.setPopupPositionAndShow(popup.getPositionCallBack());
         hide();
@@ -162,7 +163,7 @@ public final class ExportPopup extends AbstractPopupBase {
 
     }
   }
-  
+
   private static class ErrorDialog extends DialogBox {
 
     public ErrorDialog() {

--- a/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
@@ -15,6 +15,8 @@
  */
 package org.opendatakit.aggregate.client.popups;
 
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
@@ -135,8 +137,20 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
       }
 
       if (atLeastOneKmlElementCreated) {
-        SecureGWT.getFormService().createKmlFromFilter(selectedfilterGroup, kmlElementsToInclude,
-            new CreateExportCallback());
+        secureRequest(
+            SecureGWT.getFormService(),
+            (rpc, sc, cb) -> rpc.createKmlFromFilter(selectedfilterGroup, kmlElementsToInclude, cb),
+            (Boolean result) -> {
+              if (result) {
+                AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
+              } else {
+                Window.alert(EXPORT_ERROR_MSG);
+              }
+
+              hide();
+            },
+            cause -> AggregateUI.getUI().reportError(cause)
+        );
       } else {
         Window.alert(KML_ELEMENTS_ZERO_ERROR_MSG);
       }

--- a/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
@@ -140,32 +140,19 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
         secureRequest(
             SecureGWT.getFormService(),
             (rpc, sc, cb) -> rpc.createKmlFromFilter(selectedfilterGroup, kmlElementsToInclude, cb),
-            (Boolean result) -> {
-              if (result) {
-                AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
-              } else {
-                Window.alert(EXPORT_ERROR_MSG);
-              }
-
-              hide();
-            },
-            cause -> AggregateUI.getUI().reportError(cause)
+            this::onSuccess,
+            this::onFailure
         );
       } else {
         Window.alert(KML_ELEMENTS_ZERO_ERROR_MSG);
       }
     }
-  }
 
-  private class CreateExportCallback implements AsyncCallback<Boolean> {
-
-    @Override
-    public void onFailure(Throwable caught) {
-      AggregateUI.getUI().reportError(caught);
+    private void onFailure(Throwable cause) {
+      AggregateUI.getUI().reportError(cause);
     }
 
-    @Override
-    public void onSuccess(Boolean result) {
+    private void onSuccess(Boolean result) {
       if (result) {
         AggregateUI.getUI().redirectToSubTab(SubTabs.EXPORT);
       } else {

--- a/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/KmlOptionsPopup.java
@@ -15,9 +15,14 @@
  */
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HTML;
 import java.util.ArrayList;
-
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
@@ -29,25 +34,18 @@ import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
 import org.opendatakit.aggregate.constants.common.SubTabs;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.HTML;
-
 public final class KmlOptionsPopup extends AbstractPopupBase {
 
   private static final String EXPORT_ERROR_MSG = "One of the KML options was invalid. For example the Geopoint field or your Title field were invalid";
   private static final String KML_ELEMENTS_ZERO_ERROR_MSG = "To export data into KML format please select at least on KML element";
-  
+
   private static final String CREATE_BUTTON_TXT = "<img src=\"images/green_right_arrow.png\" /> Export";
   private static final String CREATE_BUTTON_TOOLTIP = "Create KML File";
   private static final String CREATE_BUTTON_HELP_BALLOON = "This exports your data into a KML file with the following options.";
 
   // this will be the standard header across the top
   private final FlexTable topBar;
-  
+
   private final AggregateButton exportButton;
 
   private final String formId;
@@ -59,7 +57,7 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
     super();
     this.formId = formid;
     this.selectedfilterGroup = selectedFilterGroup;
-    this.rows = new ArrayList<KmlSelectionGeneration>();
+    this.rows = new ArrayList<>();
 
     SecureGWT.getFormService().getPossibleKmlSettings(formId, new KmlSettingsCallback());
 
@@ -69,7 +67,7 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
 
     // disable export button until data received from server
     exportButton.setEnabled(false);
-    
+
     // set the standard header widgets
     topBar = new FlexTable();
     topBar.addStyleName("stretch_header");
@@ -80,7 +78,7 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
     topBar.setWidget(0, 6, exportButton);
     topBar.setWidget(0, 7, new ClosePopupButton(this));
 
-    
+
     FlexTable initlayout = new FlexTable();
     initlayout.setWidget(0, 0, topBar);
     setWidget(initlayout);
@@ -95,27 +93,27 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
     @Override
     public void onSuccess(KmlOptionsSummary result) {
       // eliminate kml options and refresh table
-      rows = new ArrayList<KmlSelectionGeneration>();
+      rows = new ArrayList<>();
 
       FlexTable layout = new FlexTable();
       int tableRow = 0;
       layout.setWidget(tableRow++, 0, topBar);
       layout.setWidget(tableRow++, 0, new HTML("<h2>KML Export Options:</h2>"));
-      
+
       for (KmlGeopointOption gpNode : result.getGeopointOptions()) {
-        KmlGeoPointSettingsSelectionRow row = new KmlGeoPointSettingsSelectionRow(formId,gpNode);
+        KmlGeoPointSettingsSelectionRow row = new KmlGeoPointSettingsSelectionRow(formId, gpNode);
         rows.add(row);
         layout.setWidget(tableRow++, 0, row);
       }
 
       for (KmlGeoTraceNShapeOption gtsNode : result.getGeoTraceNShapeOptions()) {
-        KmlGeoTraceNShapeSelectionRow row = new KmlGeoTraceNShapeSelectionRow(formId,gtsNode);
+        KmlGeoTraceNShapeSelectionRow row = new KmlGeoTraceNShapeSelectionRow(formId, gtsNode);
         rows.add(row);
         layout.setWidget(tableRow++, 0, row);
       }
 
       setWidget(layout);
-      
+
       // enable export button now that data has been received from server
       exportButton.setEnabled(true);
       center();
@@ -125,18 +123,18 @@ public final class KmlOptionsPopup extends AbstractPopupBase {
   private class CreateExportHandler implements ClickHandler {
     @Override
     public void onClick(ClickEvent event) {
-    
+
       boolean atLeastOneKmlElementCreated = false;
-      ArrayList<KmlSelection> kmlElementsToInclude = new ArrayList<KmlSelection>();
+      ArrayList<KmlSelection> kmlElementsToInclude = new ArrayList<>();
       for (KmlSelectionGeneration row : rows) {
-        KmlSelection kmlElement = row.generateKmlSelection(); 
+        KmlSelection kmlElement = row.generateKmlSelection();
         if (kmlElement != null) {
           atLeastOneKmlElementCreated = true;
           kmlElementsToInclude.add(kmlElement);
         }
       }
-      
-      if(atLeastOneKmlElementCreated) {
+
+      if (atLeastOneKmlElementCreated) {
         SecureGWT.getFormService().createKmlFromFilter(selectedfilterGroup, kmlElementsToInclude,
             new CreateExportCallback());
       } else {

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -327,8 +327,12 @@ public final class PublishPopup extends AbstractPopupBase {
           );
           break;
         case REDCAP_SERVER:
-          SecureGWT.getServicesAdminService().createRedCapServer(formId, rcApiKey.getText(),
-              rcUrl.getText(), serviceOp, ownerEmail, new ReportFailureCallback());
+          secureRequest(
+              SecureGWT.getServicesAdminService(),
+              (rpc, sc, cb) -> rpc.createRedCapServer(formId, rcApiKey.getText(), rcUrl.getText(), serviceOp, ownerEmail, cb),
+              (String __) -> {},
+              cause -> AggregateUI.getUI().reportError(cause)
+          );
           break;
         case JSON_SERVER: {
           String jsBinaryOpString = jsBinaryOptions.getSelectedValue();

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -346,10 +346,15 @@ public final class PublishPopup extends AbstractPopupBase {
         }
         break;
         case OHMAGE_JSON_SERVER:
-          SecureGWT.getServicesAdminService().createOhmageJsonServer(formId,
-              ohmageCampaignUrn.getText(), ohmageCampaignTimestamp.getText(),
-              ohmageUsername.getText(), ohmageHashedPassword.getText(), ohmageUrl.getText(),
-              serviceOp, ownerEmail, new ReportFailureCallback());
+          secureRequest(
+              SecureGWT.getServicesAdminService(),
+              (rpc, sc, cb) -> rpc.createOhmageJsonServer(formId,
+                  ohmageCampaignUrn.getText(), ohmageCampaignTimestamp.getText(),
+                  ohmageUsername.getText(), ohmageHashedPassword.getText(), ohmageUrl.getText(),
+                  serviceOp, ownerEmail, cb),
+              (String __) -> {},
+              cause -> AggregateUI.getUI().reportError(cause)
+          );
           break;
         case GOOGLE_FUSIONTABLES:
           secureRequest(

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -23,11 +23,11 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.TextBox;
+import java.util.function.Consumer;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.UIUtils;
@@ -55,6 +55,8 @@ public final class PublishPopup extends AbstractPopupBase {
 
   private static final String BO_TYPE_TOOLTIP = "Sets how the binary data from Media should be published";
   private static final String BO_TYPE_BALLOON = "Selects how the binary dat from Media should be published. Aggregate will provide links in the publish OR will embed the data in the publish";
+  public static final Consumer<String> NO_OP_CONSUMER = (String __) -> {
+  };
 
   // this is the main flex table for the popup
   private final FlexTable layout;
@@ -322,16 +324,16 @@ public final class PublishPopup extends AbstractPopupBase {
           secureRequest(
               SecureGWT.getServicesAdminService(),
               (rpc, sc, cb) -> rpc.createGoogleSpreadsheet(formId, gsName.getText(), serviceOp, ownerEmail, cb),
-              (String __) -> {},
-              cause -> AggregateUI.getUI().reportError(cause)
+              NO_OP_CONSUMER,
+              this::onFailure
           );
           break;
         case REDCAP_SERVER:
           secureRequest(
               SecureGWT.getServicesAdminService(),
               (rpc, sc, cb) -> rpc.createRedCapServer(formId, rcApiKey.getText(), rcUrl.getText(), serviceOp, ownerEmail, cb),
-              (String __) -> {},
-              cause -> AggregateUI.getUI().reportError(cause)
+              NO_OP_CONSUMER,
+              this::onFailure
           );
           break;
         case JSON_SERVER: {
@@ -340,8 +342,8 @@ public final class PublishPopup extends AbstractPopupBase {
           secureRequest(
               SecureGWT.getServicesAdminService(),
               (rpc, sc, cb) -> rpc.createSimpleJsonServer(formId, jsAuthKey.getText(), jsUrl.getText(), serviceOp, ownerEmail, jsBinaryOp, cb),
-              (String __) -> {},
-              cause -> AggregateUI.getUI().reportError(cause)
+              NO_OP_CONSUMER,
+              this::onFailure
           );
         }
         break;
@@ -352,16 +354,16 @@ public final class PublishPopup extends AbstractPopupBase {
                   ohmageCampaignUrn.getText(), ohmageCampaignTimestamp.getText(),
                   ohmageUsername.getText(), ohmageHashedPassword.getText(), ohmageUrl.getText(),
                   serviceOp, ownerEmail, cb),
-              (String __) -> {},
-              cause -> AggregateUI.getUI().reportError(cause)
+              NO_OP_CONSUMER,
+              this::onFailure
           );
           break;
         case GOOGLE_FUSIONTABLES:
           secureRequest(
               SecureGWT.getServicesAdminService(),
               (rpc, sc, cb) -> rpc.createFusionTable(formId, serviceOp, ownerEmail, cb),
-              (String __) -> {},
-              cause -> AggregateUI.getUI().reportError(cause)
+              NO_OP_CONSUMER,
+              this::onFailure
           );
           break;
         default: // unknown type
@@ -369,6 +371,10 @@ public final class PublishPopup extends AbstractPopupBase {
       }
 
       hide();
+    }
+
+    private void onFailure(Throwable cause) {
+      AggregateUI.getUI().reportError(cause);
     }
 
     private String getOwnerEmail(UserSecurityInfo info) {
@@ -381,16 +387,6 @@ public final class PublishPopup extends AbstractPopupBase {
         }
       }
       return ownerEmail;
-    }
-  }
-
-  private class ReportFailureCallback implements AsyncCallback<String> {
-
-    public void onFailure(Throwable caught) {
-      AggregateUI.getUI().reportError(caught);
-    }
-
-    public void onSuccess(String result) {
     }
   }
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -335,10 +335,14 @@ public final class PublishPopup extends AbstractPopupBase {
           );
           break;
         case JSON_SERVER: {
-          String jsBinaryOpString = jsBinaryOptions.getSelectedValue();
-          BinaryOption jsBinaryOp = (jsBinaryOpString == null) ? null : BinaryOption.valueOf(jsBinaryOpString);
-          SecureGWT.getServicesAdminService().createSimpleJsonServer(formId, jsAuthKey.getText(),
-              jsUrl.getText(), serviceOp, ownerEmail, jsBinaryOp, new ReportFailureCallback());
+          final String jsBinaryOpString = jsBinaryOptions.getSelectedValue();
+          final BinaryOption jsBinaryOp = (jsBinaryOpString == null) ? null : BinaryOption.valueOf(jsBinaryOpString);
+          secureRequest(
+              SecureGWT.getServicesAdminService(),
+              (rpc, sc, cb) -> rpc.createSimpleJsonServer(formId, jsAuthKey.getText(), jsUrl.getText(), serviceOp, ownerEmail, jsBinaryOp, cb),
+              (String __) -> {},
+              cause -> AggregateUI.getUI().reportError(cause)
+          );
         }
         break;
         case OHMAGE_JSON_SERVER:

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -16,7 +16,16 @@
 
 package org.opendatakit.aggregate.client.popups;
 
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.TextBox;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.UIUtils;
@@ -27,16 +36,6 @@ import org.opendatakit.aggregate.constants.common.BinaryOption;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
 import org.opendatakit.aggregate.constants.common.ExternalServiceType;
 import org.opendatakit.common.security.client.UserSecurityInfo;
-
-import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.TextBox;
 
 public final class PublishPopup extends AbstractPopupBase {
 
@@ -51,10 +50,10 @@ public final class PublishPopup extends AbstractPopupBase {
   private static final String ES_SERVICEOPTIONS_BALLOON = "Choose whether you would like only old data, only new data, or all data to be published.";
   private static final String ES_TYPE_TOOLTIP = "Type of External Service Connection";
   private static final String ES_TYPE_BALLOON = "Select the application where you want your data to be published.";
- 
+
   private static final String BO_TYPE_TOOLTIP = "Sets how the binary data from Media should be published";
   private static final String BO_TYPE_BALLOON = "Selects how the binary dat from Media should be published. Aggregate will provide links in the publish OR will embed the data in the publish";
-  
+
   // this is the main flex table for the popup
   private final FlexTable layout;
   // this is the header
@@ -99,18 +98,18 @@ public final class PublishPopup extends AbstractPopupBase {
     this.publishButton = new AggregateButton(BUTTON_TXT, TOOLTIP_TXT, HELP_BALLOON_TXT);
     publishButton.addClickHandler(new CreateExernalServiceHandler());
 
-    ExternalServiceType[] valuesToShow = { ExternalServiceType.GOOGLE_FUSIONTABLES,
+    ExternalServiceType[] valuesToShow = {ExternalServiceType.GOOGLE_FUSIONTABLES,
         ExternalServiceType.GOOGLE_SPREADSHEET,
         ExternalServiceType.REDCAP_SERVER, ExternalServiceType.JSON_SERVER,
-        ExternalServiceType.OHMAGE_JSON_SERVER };
-    serviceType = new EnumListBox<ExternalServiceType>(valuesToShow, ES_TYPE_TOOLTIP,
+        ExternalServiceType.OHMAGE_JSON_SERVER};
+    serviceType = new EnumListBox<>(valuesToShow, ES_TYPE_TOOLTIP,
         ES_TYPE_BALLOON);
     serviceType.addChangeHandler(new ExternalServiceTypeChangeHandler());
 
-    esOptions = new EnumListBox<ExternalServicePublicationOption>(
+    esOptions = new EnumListBox<>(
         ExternalServicePublicationOption.values(), ES_SERVICEOPTIONS_TOOLTIP,
         ES_SERVICEOPTIONS_BALLOON);
-    
+
     // Set up the tables in the popup
     layout = new FlexTable();
 
@@ -145,7 +144,7 @@ public final class PublishPopup extends AbstractPopupBase {
     jsBar.setWidget(1, 0, new HTML("<h3>Url to publish to:</h3>"));
     jsUrl = new TextBox();
     jsUrl.setText(HTTP_LOCALHOST);
-    jsUrl.setVisibleLength(60); 
+    jsUrl.setVisibleLength(60);
     jsBar.setWidget(1, 1, jsUrl);
     // get token
     jsBar.setWidget(2, 0, new HTML("<h3>Authorization token:</h3>"));
@@ -155,11 +154,11 @@ public final class PublishPopup extends AbstractPopupBase {
     jsBar.setWidget(2, 1, jsAuthKey);
     // make the options for how to handle the binary 
     jsBar.setWidget(3, 0, new HTML("<h3>Include Media as:</h3>"));
-    jsBinaryOptions = new EnumListBox<BinaryOption>(
+    jsBinaryOptions = new EnumListBox<>(
         BinaryOption.values(), BO_TYPE_TOOLTIP,
         BO_TYPE_BALLOON);
     jsBar.setWidget(3, 1, jsBinaryOptions);
-    
+
     // this is only for ohmage server
     ohmageBar = new FlexTable();
     ohmageBar.addStyleName("stretch_header");
@@ -235,10 +234,10 @@ public final class PublishPopup extends AbstractPopupBase {
   public void updateUIOptions() {
     System.out.println("UPDATE UI OPTIONS CALLED");
     System.out.println("Type:" + serviceType.getSelectedValue());
-    
+
     String externalServiceTypeString = serviceType.getSelectedValue();
     ExternalServiceType type = (externalServiceTypeString == null) ? null :
-      ExternalServiceType.valueOf(externalServiceTypeString);
+        ExternalServiceType.valueOf(externalServiceTypeString);
 
     if (type == null) {
       gsBar.setVisible(false);
@@ -252,49 +251,49 @@ public final class PublishPopup extends AbstractPopupBase {
     publishButton.setEnabled(true);
 
     switch (type) {
-    case GOOGLE_SPREADSHEET:
-      gsBar.setVisible(true);
-      jsBar.setVisible(false);
-      rcBar.setVisible(false);
-      ohmageBar.setVisible(false);
-      optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
-      break;
-    case JSON_SERVER:
-      gsBar.setVisible(false);
-      jsBar.setVisible(true);
-      rcBar.setVisible(false);
-      ohmageBar.setVisible(false);
-      optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
-      break;
-    case OHMAGE_JSON_SERVER:
-      gsBar.setVisible(false);
-      jsBar.setVisible(false);
-      rcBar.setVisible(false);
-      ohmageBar.setVisible(true);
-      optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
-      break;
-    case REDCAP_SERVER:
-      gsBar.setVisible(false);
-      jsBar.setVisible(false);
-      rcBar.setVisible(true);
-      ohmageBar.setVisible(false);
-      optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
-      break;
-    case GOOGLE_FUSIONTABLES:
-      gsBar.setVisible(false);
-      jsBar.setVisible(false);
-      rcBar.setVisible(false);
-      ohmageBar.setVisible(false);
-      optionsBar.getRowFormatter().setStyleName(2, "disabledTableRow");
-      break;
-    default: // unknown type
-      gsBar.setVisible(false);
-      jsBar.setVisible(false);
-      rcBar.setVisible(false);
-      ohmageBar.setVisible(false);
-      optionsBar.getRowFormatter().setStyleName(2, "disabledTableRow");
-      publishButton.setEnabled(false);
-      break;
+      case GOOGLE_SPREADSHEET:
+        gsBar.setVisible(true);
+        jsBar.setVisible(false);
+        rcBar.setVisible(false);
+        ohmageBar.setVisible(false);
+        optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
+        break;
+      case JSON_SERVER:
+        gsBar.setVisible(false);
+        jsBar.setVisible(true);
+        rcBar.setVisible(false);
+        ohmageBar.setVisible(false);
+        optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
+        break;
+      case OHMAGE_JSON_SERVER:
+        gsBar.setVisible(false);
+        jsBar.setVisible(false);
+        rcBar.setVisible(false);
+        ohmageBar.setVisible(true);
+        optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
+        break;
+      case REDCAP_SERVER:
+        gsBar.setVisible(false);
+        jsBar.setVisible(false);
+        rcBar.setVisible(true);
+        ohmageBar.setVisible(false);
+        optionsBar.getRowFormatter().setStyleName(2, "enabledTableRow");
+        break;
+      case GOOGLE_FUSIONTABLES:
+        gsBar.setVisible(false);
+        jsBar.setVisible(false);
+        rcBar.setVisible(false);
+        ohmageBar.setVisible(false);
+        optionsBar.getRowFormatter().setStyleName(2, "disabledTableRow");
+        break;
+      default: // unknown type
+        gsBar.setVisible(false);
+        jsBar.setVisible(false);
+        rcBar.setVisible(false);
+        ohmageBar.setVisible(false);
+        optionsBar.getRowFormatter().setStyleName(2, "disabledTableRow");
+        publishButton.setEnabled(false);
+        break;
     }
   }
 
@@ -305,11 +304,11 @@ public final class PublishPopup extends AbstractPopupBase {
 
       String externalServiceTypeString = serviceType.getSelectedValue();
       ExternalServiceType type = (externalServiceTypeString == null) ? null :
-        ExternalServiceType.valueOf(externalServiceTypeString);
+          ExternalServiceType.valueOf(externalServiceTypeString);
 
       String serviceOpString = esOptions.getSelectedValue();
       ExternalServicePublicationOption serviceOp = (serviceOpString == null) ? null :
-        ExternalServicePublicationOption.valueOf(serviceOpString);
+          ExternalServicePublicationOption.valueOf(serviceOpString);
 
       UserSecurityInfo info = AggregateUI.getUI().getUserInfo();
       String ownerEmail = info.getEmail();
@@ -322,34 +321,33 @@ public final class PublishPopup extends AbstractPopupBase {
       }
 
       switch (type) {
-      case GOOGLE_SPREADSHEET:
-        SecureGWT.getServicesAdminService().createGoogleSpreadsheet(formId, gsName.getText(),
-            serviceOp, ownerEmail, new ReportFailureCallback());
+        case GOOGLE_SPREADSHEET:
+          SecureGWT.getServicesAdminService().createGoogleSpreadsheet(formId, gsName.getText(),
+              serviceOp, ownerEmail, new ReportFailureCallback());
+          break;
+        case REDCAP_SERVER:
+          SecureGWT.getServicesAdminService().createRedCapServer(formId, rcApiKey.getText(),
+              rcUrl.getText(), serviceOp, ownerEmail, new ReportFailureCallback());
+          break;
+        case JSON_SERVER: {
+          String jsBinaryOpString = jsBinaryOptions.getSelectedValue();
+          BinaryOption jsBinaryOp = (jsBinaryOpString == null) ? null : BinaryOption.valueOf(jsBinaryOpString);
+          SecureGWT.getServicesAdminService().createSimpleJsonServer(formId, jsAuthKey.getText(),
+              jsUrl.getText(), serviceOp, ownerEmail, jsBinaryOp, new ReportFailureCallback());
+        }
         break;
-      case REDCAP_SERVER:
-        SecureGWT.getServicesAdminService().createRedCapServer(formId, rcApiKey.getText(),
-            rcUrl.getText(), serviceOp, ownerEmail, new ReportFailureCallback());
-        break;
-      case JSON_SERVER:
-      {
-        String jsBinaryOpString = jsBinaryOptions.getSelectedValue();
-        BinaryOption jsBinaryOp = (jsBinaryOpString == null) ? null : BinaryOption.valueOf(jsBinaryOpString);
-        SecureGWT.getServicesAdminService().createSimpleJsonServer(formId, jsAuthKey.getText(),
-            jsUrl.getText(), serviceOp, ownerEmail, jsBinaryOp, new ReportFailureCallback());
-      }
-        break;
-      case OHMAGE_JSON_SERVER:
-        SecureGWT.getServicesAdminService().createOhmageJsonServer(formId,
-            ohmageCampaignUrn.getText(), ohmageCampaignTimestamp.getText(),
-            ohmageUsername.getText(), ohmageHashedPassword.getText(), ohmageUrl.getText(),
-            serviceOp, ownerEmail, new ReportFailureCallback());
-        break;
-      case GOOGLE_FUSIONTABLES:
-        SecureGWT.getServicesAdminService().createFusionTable(formId, serviceOp, ownerEmail,
-            new ReportFailureCallback());
-        break;
-      default: // unknown type
-        break;
+        case OHMAGE_JSON_SERVER:
+          SecureGWT.getServicesAdminService().createOhmageJsonServer(formId,
+              ohmageCampaignUrn.getText(), ohmageCampaignTimestamp.getText(),
+              ohmageUsername.getText(), ohmageHashedPassword.getText(), ohmageUrl.getText(),
+              serviceOp, ownerEmail, new ReportFailureCallback());
+          break;
+        case GOOGLE_FUSIONTABLES:
+          SecureGWT.getServicesAdminService().createFusionTable(formId, serviceOp, ownerEmail,
+              new ReportFailureCallback());
+          break;
+        default: // unknown type
+          break;
       }
 
       hide();

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -319,8 +319,12 @@ public final class PublishPopup extends AbstractPopupBase {
 
       switch (type) {
         case GOOGLE_SPREADSHEET:
-          SecureGWT.getServicesAdminService().createGoogleSpreadsheet(formId, gsName.getText(),
-              serviceOp, ownerEmail, new ReportFailureCallback());
+          secureRequest(
+              SecureGWT.getServicesAdminService(),
+              (rpc, sc, cb) -> rpc.createGoogleSpreadsheet(formId, gsName.getText(), serviceOp, ownerEmail, cb),
+              (String __) -> {},
+              cause -> AggregateUI.getUI().reportError(cause)
+          );
           break;
         case REDCAP_SERVER:
           SecureGWT.getServicesAdminService().createRedCapServer(formId, rcApiKey.getText(),

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
@@ -32,6 +32,9 @@ import org.opendatakit.aggregate.constants.common.ExternalServiceType;
  */
 public final class RestartButton extends AggregateButton implements ClickHandler {
 
+  public static final Runnable NO_OP_RUNNABLE = () -> {
+  };
+
   public enum Circumstance {CREDENTIALS, ABANDONED, PAUSED}
 
   ;
@@ -61,16 +64,6 @@ public final class RestartButton extends AggregateButton implements ClickHandler
     addStyleDependentName("negative");
   }
 
-  private class ReportErrorsCallback implements AsyncCallback<Void> {
-
-    public void onFailure(Throwable caught) {
-      AggregateUI.getUI().reportError(caught);
-    }
-
-    public void onSuccess(Void result) {
-    }
-  }
-
   @Override
   public void onClick(ClickEvent event) {
     super.onClick(event);
@@ -89,18 +82,22 @@ public final class RestartButton extends AggregateButton implements ClickHandler
         secureRequest(
             SecureGWT.getServicesAdminService(),
             (rpc, sc, cb) -> rpc.updateApiKeyAndRestartPublisher(publisher.getUri(), apiKey, cb),
-            () -> {},
-            cause -> AggregateUI.getUI().reportError(cause)
+            NO_OP_RUNNABLE,
+            this::onFailure
         );
         break;
       default:
         secureRequest(
             SecureGWT.getServicesAdminService(),
             (rpc, sc, cb) -> rpc.restartPublisher(publisher.getUri(), cb),
-            () -> {},
-            cause -> AggregateUI.getUI().reportError(cause)
+            NO_OP_RUNNABLE,
+            this::onFailure
         );
         break;
     }
+  }
+
+  private void onFailure(Throwable cause) {
+    AggregateUI.getUI().reportError(cause);
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
@@ -16,23 +16,24 @@
 
 package org.opendatakit.aggregate.client.widgets;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.UIUtils;
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
 import org.opendatakit.aggregate.constants.common.ExternalServiceType;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-
 /**
  * Restarts Publisher because of failures
  */
 public final class RestartButton extends AggregateButton implements ClickHandler {
 
-  public enum Circumstance { CREDENTIALS, ABANDONED, PAUSED };
-  
+  public enum Circumstance {CREDENTIALS, ABANDONED, PAUSED}
+
+  ;
+
   private static final String BUTTON_BAD_CREDENTIAL_TXT = "<b><img src=\"images/green_right_arrow.png\" /> Restart Publisher - Credential was BAD";
   private static final String TOOLTIP_BAD_CREDENTIAL_TEXT = "Publish failure because of bad credential - click to Restart the Publisher";
   private static final String HELP_BALLOON_BAD_CREDENTIAL_TXT = "The external service was failing or the credentials were bad. Click to restart the publisher.";
@@ -48,12 +49,12 @@ public final class RestartButton extends AggregateButton implements ClickHandler
   private final ExternServSummary publisher;
 
   public RestartButton(ExternServSummary publisher, Circumstance credentialFailure) {
-    super((credentialFailure == Circumstance.CREDENTIALS) ? BUTTON_BAD_CREDENTIAL_TXT : 
-          ((credentialFailure == Circumstance.CREDENTIALS) ? BUTTON_FAILURE_TXT : BUTTON_PAUSED_TXT),
-          (credentialFailure == Circumstance.CREDENTIALS) ? TOOLTIP_BAD_CREDENTIAL_TEXT : 
+    super((credentialFailure == Circumstance.CREDENTIALS) ? BUTTON_BAD_CREDENTIAL_TXT :
+            ((credentialFailure == Circumstance.CREDENTIALS) ? BUTTON_FAILURE_TXT : BUTTON_PAUSED_TXT),
+        (credentialFailure == Circumstance.CREDENTIALS) ? TOOLTIP_BAD_CREDENTIAL_TEXT :
             ((credentialFailure == Circumstance.CREDENTIALS) ? TOOLTIP_FAILURE_TEXT : TOOLTIP_PAUSED_TEXT),
-            (credentialFailure == Circumstance.CREDENTIALS) ? HELP_BALLOON_BAD_CREDENTIAL_TXT : 
-              ((credentialFailure == Circumstance.CREDENTIALS) ? HELP_BALLOON_FAILURE_TXT : HELP_BALLOON_PAUSED_TXT));
+        (credentialFailure == Circumstance.CREDENTIALS) ? HELP_BALLOON_BAD_CREDENTIAL_TXT :
+            ((credentialFailure == Circumstance.CREDENTIALS) ? HELP_BALLOON_FAILURE_TXT : HELP_BALLOON_PAUSED_TXT));
     this.publisher = publisher;
     addStyleDependentName("negative");
   }
@@ -76,20 +77,20 @@ public final class RestartButton extends AggregateButton implements ClickHandler
 
     switch (type) {
 
-    case REDCAP_SERVER:
-      String apiKey;
-      try {
-        apiKey = UIUtils.promptForREDCapApiKey();
-      } catch (Exception e) {
-        return; // user pressed cancel
-      }
-      SecureGWT.getServicesAdminService().updateApiKeyAndRestartPublisher(publisher.getUri(),
-          apiKey, new ReportErrorsCallback());
-      break;
-    default:
-      SecureGWT.getServicesAdminService().restartPublisher(publisher.getUri(),
-          new ReportErrorsCallback());
-      break;
+      case REDCAP_SERVER:
+        String apiKey;
+        try {
+          apiKey = UIUtils.promptForREDCapApiKey();
+        } catch (Exception e) {
+          return; // user pressed cancel
+        }
+        SecureGWT.getServicesAdminService().updateApiKeyAndRestartPublisher(publisher.getUri(),
+            apiKey, new ReportErrorsCallback());
+        break;
+      default:
+        SecureGWT.getServicesAdminService().restartPublisher(publisher.getUri(),
+            new ReportErrorsCallback());
+        break;
     }
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
@@ -94,8 +94,12 @@ public final class RestartButton extends AggregateButton implements ClickHandler
         );
         break;
       default:
-        SecureGWT.getServicesAdminService().restartPublisher(publisher.getUri(),
-            new ReportErrorsCallback());
+        secureRequest(
+            SecureGWT.getServicesAdminService(),
+            (rpc, sc, cb) -> rpc.restartPublisher(publisher.getUri(), cb),
+            () -> {},
+            cause -> AggregateUI.getUI().reportError(cause)
+        );
         break;
     }
   }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/RestartButton.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client.widgets;
 
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -84,8 +86,12 @@ public final class RestartButton extends AggregateButton implements ClickHandler
         } catch (Exception e) {
           return; // user pressed cancel
         }
-        SecureGWT.getServicesAdminService().updateApiKeyAndRestartPublisher(publisher.getUri(),
-            apiKey, new ReportErrorsCallback());
+        secureRequest(
+            SecureGWT.getServicesAdminService(),
+            (rpc, sc, cb) -> rpc.updateApiKeyAndRestartPublisher(publisher.getUri(), apiKey, cb),
+            () -> {},
+            cause -> AggregateUI.getUI().reportError(cause)
+        );
         break;
       default:
         SecureGWT.getServicesAdminService().restartPublisher(publisher.getUri(),

--- a/src/main/java/org/opendatakit/aggregate/server/FormServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/FormServiceImpl.java
@@ -16,6 +16,7 @@
 
 package org.opendatakit.aggregate.server;
 
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,11 +24,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -57,10 +54,9 @@ import org.opendatakit.common.persistence.client.exception.DatastoreFailureExcep
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.persistence.exception.ODKEntityNotFoundException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
-import org.opendatakit.common.security.client.exception.AccessDeniedException;
 import org.opendatakit.common.web.CallingContext;
-
-import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FormServiceImpl extends RemoteServiceServlet implements
     org.opendatakit.aggregate.client.form.FormService {
@@ -111,16 +107,17 @@ public class FormServiceImpl extends RemoteServiceServlet implements
           summary.setMostRecentPurgeSubmissionsRequestStatus(t);
         }
       }
-      Collections.sort(formSummaries, new Comparator<FormSummary>(){
+      Collections.sort(formSummaries, new Comparator<FormSummary>() {
 
         @Override
         public int compare(FormSummary arg0, FormSummary arg1) {
           int cmp;
           cmp = arg0.getTitle().compareTo(arg1.getTitle());
-          if ( cmp != 0 ) return cmp;
+          if (cmp != 0) return cmp;
           cmp = arg0.getId().compareTo(arg1.getId());
           return cmp;
-        }});
+        }
+      });
 
       return formSummaries;
 
@@ -137,7 +134,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public ArrayList<ExportSummary> getExports() throws RequestFailureException, FormNotAvailableException, DatastoreFailureException {
+  public ArrayList<ExportSummary> getExports() throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -183,7 +180,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public KmlOptionsSummary getPossibleKmlSettings(String formId) throws RequestFailureException, FormNotAvailableException, DatastoreFailureException {
+  public KmlOptionsSummary getPossibleKmlSettings(String formId) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -208,7 +205,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public GeopointElementList getGpsCoordnates(String formId) throws RequestFailureException, FormNotAvailableException, DatastoreFailureException {
+  public GeopointElementList getGpsCoordnates(String formId) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -234,7 +231,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public Boolean createCsvFromFilter(FilterGroup group) throws AccessDeniedException, FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+  public Boolean createCsvFromFilter(FilterGroup group) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -283,8 +280,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public Boolean createJsonFileFromFilter(FilterGroup group) throws AccessDeniedException,
-      FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+  public Boolean createJsonFileFromFilter(FilterGroup group) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -332,7 +328,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public Boolean createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude) throws FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+  public Boolean createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -408,21 +404,21 @@ public class FormServiceImpl extends RemoteServiceServlet implements
 //        }
 //      }
 
-      
+
       // encode all the settings form the selections
       StringBuilder encodedKmlSettings = new StringBuilder();
       boolean firstItem = true;
-      for(KmlSelection kmlSetting : kmlElementsToInclude) {
-        if(firstItem) {
+      for (KmlSelection kmlSetting : kmlElementsToInclude) {
+        if (firstItem) {
           firstItem = false;
         } else {
           encodedKmlSettings.append(KmlGenerator.KML_SELECTIONS_DELIMITER);
         }
         // TODO: think about a bad setting (checking comment out above will prevent this);
         String tmpString = kmlSetting.generateEncodedString();
-        encodedKmlSettings.append(tmpString );
+        encodedKmlSettings.append(tmpString);
       }
-      
+
       Map<String, String> params = new HashMap<String, String>();
       params.put(KmlGenerator.KML_SELECTIONS_KEY, encodedKmlSettings.toString());
 
@@ -447,8 +443,7 @@ public class FormServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public void deleteExport(String uri) throws AccessDeniedException, FormNotAvailableException,
-      RequestFailureException, DatastoreFailureException {
+  public void deleteExport(String uri) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 

--- a/src/main/java/org/opendatakit/aggregate/server/ServicesAdminServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/ServicesAdminServiceImpl.java
@@ -16,10 +16,9 @@
 
 package org.opendatakit.aggregate.server;
 
+import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
-
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.FormNotAvailableException;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -48,23 +47,17 @@ import org.opendatakit.common.persistence.client.exception.DatastoreFailureExcep
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.persistence.exception.ODKEntityNotFoundException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
-import org.opendatakit.common.security.client.exception.AccessDeniedException;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
-
-import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
 public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
     org.opendatakit.aggregate.client.externalserv.ServicesAdminService {
 
-  /**
-     *
-     */
   private static final long serialVersionUID = 51251316598366231L;
 
   @Override
-  public ExternServSummary[] getExternalServices(String formId) throws AccessDeniedException,
-      FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+  public ExternServSummary[] getExternalServices(String formId) throws
+      RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -103,7 +96,7 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
 
   @Override
   public String createFusionTable(String formId, ExternalServicePublicationOption esOption,
-      String ownerEmail) throws AccessDeniedException, FormNotAvailableException,
+                                  String ownerEmail) throws
       RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
@@ -143,8 +136,8 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
 
   @Override
   public String createGoogleSpreadsheet(String formId, String name,
-      ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException,
-      FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+                                        ExternalServicePublicationOption esOption, String ownerEmail) throws
+      RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -186,8 +179,8 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
 
   @Override
   public String createRedCapServer(String formId, String apiKey, String url,
-      ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException,
-      FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+                                   ExternalServicePublicationOption esOption, String ownerEmail) throws
+      RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -222,8 +215,8 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
 
   @Override
   public String createSimpleJsonServer(String formId, String authKey, String url,
-      ExternalServicePublicationOption esOption, String ownerEmail, BinaryOption binaryOption)
-      throws AccessDeniedException, FormNotAvailableException, RequestFailureException,
+                                       ExternalServicePublicationOption esOption, String ownerEmail, BinaryOption binaryOption)
+      throws RequestFailureException,
       DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
@@ -260,8 +253,8 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
 
   @Override
   public String createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp,
-      String user, String hashedPassword, String url, ExternalServicePublicationOption esOption,
-      String ownerEmail) throws AccessDeniedException, FormNotAvailableException,
+                                       String user, String hashedPassword, String url, ExternalServicePublicationOption esOption,
+                                       String ownerEmail) throws
       RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
@@ -297,8 +290,8 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public Boolean deletePublisher(String uri) throws AccessDeniedException,
-      FormNotAvailableException, RequestFailureException, DatastoreFailureException {
+  public Boolean deletePublisher(String uri) throws
+      RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -345,8 +338,7 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
   }
 
   @Override
-  public void restartPublisher(String uri) throws AccessDeniedException, FormNotAvailableException,
-      RequestFailureException, DatastoreFailureException {
+  public void restartPublisher(String uri) throws RequestFailureException, DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
@@ -361,9 +353,9 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
         throw new RequestFailureException("Service description not found for this publisher");
       }
       OperationalStatus status = fsc.getOperationalStatus();
-      if ( status != OperationalStatus.BAD_CREDENTIALS && 
-           status != OperationalStatus.ABANDONED &&
-           status != OperationalStatus.PAUSED ) {
+      if (status != OperationalStatus.BAD_CREDENTIALS &&
+          status != OperationalStatus.ABANDONED &&
+          status != OperationalStatus.PAUSED) {
         throw new RequestFailureException(
             "Rejecting change request -- publisher is not in a failure state");
       }
@@ -391,7 +383,7 @@ public class ServicesAdminServiceImpl extends RemoteServiceServlet implements
 
   @Override
   public void updateApiKeyAndRestartPublisher(String uri, String apiKey)
-      throws AccessDeniedException, FormNotAvailableException, RequestFailureException,
+      throws RequestFailureException,
       DatastoreFailureException {
     HttpServletRequest req = this.getThreadLocalRequest();
     CallingContext cc = ContextFactory.getCallingContext(this, req);


### PR DESCRIPTION
This PR adds extra security protections to some RPC calls:
- Export submissions to CSV, JSON, and KML
- Create publishers: Fusion Table, Google Spreadsheet, RedCap Server, SimpleJSON Server, Ohmage Server
- Delete publisher
- Update Publisher API key and restart

~This PR is developed on top of #303 and it starts after commit e3035b0~
(the branch has been rebased after merging #303 into master)

#### What has been done to verify that this works as intended?
First, I've manually verified that all these operations still work in my local Aggregate instance
Second, I've inspected the network interchange of the delete form action and I've resent it using curl from the command line to verify that it won't work since the CSRF token wasn't valid anymore.

#### Why is this the best possible solution? Were any other approaches considered?
This solution implements the [official instructions](http://www.gwtproject.org/doc/latest/DevGuideSecurityRpcXsrf.html) to add CSRF protection to GWT apps.

To reduce code duplication and complexity, I've created a wrapper that handles client-side CSRF requests.

#### Are there any risks to merging this code? If so, what are they?
Any third party hitting these RPCs will have to request a CSRF token before making them. 

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.