### PR TITLE
Issue 312 fix aggregate config

### DIFF
--- a/docs/build-and-run-a-virtual-machine.md
+++ b/docs/build-and-run-a-virtual-machine.md
@@ -32,4 +32,7 @@ The VM is configured to use a NAT network device by default and will make the fo
 ## Network configuration
 
 - If you need to change the network configuration, log into your Aggregate VM using a terminal and run `aggregate-config`. 
-  - This is a tool that lets you configure your VM to use different FQDN and ports. You can run the tool without arguments to get a help message.
+  
+  This is a tool that lets you configure your VM to use different FQDN and ports. You can run the tool without arguments to get a help message.
+  
+  You need to use this tool if you want to use a bridged network device in your VM (or to switch back to a NAT network device)

--- a/packer/ansible/roles/aggregate/files/aggregate-config.sh
+++ b/packer/ansible/roles/aggregate/files/aggregate-config.sh
@@ -58,26 +58,26 @@ showHelp() {
   echo "--net-mode   <value> Set the VM's network mode. Use 'nat' or 'bridge'"
 }
 
-if [ ${HELP} = YES ]; then
+if [ "${HELP}" = YES ]; then
   showHelp
   exit 0
 fi
 
-if [ ${NET_MODE} != "nat" ] && [ ${NET_MODE} != "bridge" ]; then
+if [ "${NET_MODE}" != "nat" ] && [ "${NET_MODE}" != "bridge" ]; then
   echo "Error: Invalid --net-mode value. Use 'nat' or 'bridge' according to the VM's networking configuration"
   echo ""
   showHelp
   exit 1
 fi
 
-if [ ${NET_MODE} == "bridge" ] && ([ -z ${HTTP_PORT} ] || [ -z ${HTTPS_PORT} ]); then
+if [ "${NET_MODE}" == "bridge" ] && ([ -z "${HTTP_PORT}" ] || [ -z "${HTTPS_PORT}" ]); then
   echo "Error: In net mode 'bridge' you need to provide values for --http-port and --https-port"
   echo ""
   showHelp
   exit 1
 fi
 
-if [ ${HELP} = NO ] && [ -z ${FQDN} ] && [ -z ${HTTP_PORT} ] && [ -z ${HTTPS_PORT} ]; then
+if [ "${HELP}" = NO ] && [ -z "${FQDN}" ] && [ -z "${HTTP_PORT}" ] && [ -z "${HTTPS_PORT}" ]; then
   echo "Error: You need to set at least one argument"
   echo ""
   showHelp
@@ -88,33 +88,33 @@ echo "Stopping Tomcat. Please wait..."
 echo ""
 service tomcat8 stop
 
-if [ ! -z ${FQDN} ] && [ ${FQDN} = "auto" ]; then
-  cat ${PROPS_FILE} | sed -e "s/^security\.server\.hostname=.*$/security.server.hostname=/" > /tmp/temp_file
+if [ ! -z "${FQDN}" ] && [ "${FQDN}" = "auto" ]; then
+  sed -e "s/^security\.server\.hostname=.*$/security.server.hostname=/" ${PROPS_FILE} > /tmp/temp_file
   cp /tmp/temp_file ${PROPS_FILE}
 fi
 
-if [ ! -z ${FQDN} ] && [ ! ${FQDN} = "auto" ]; then
-  cat ${PROPS_FILE} | sed -e "s/^security\.server\.hostname=.*$/security.server.hostname=${FQDN}/" > /tmp/temp_file
+if [ ! -z "${FQDN}" ] && [ ! "${FQDN}" = "auto" ]; then
+  sed -e "s/^security\.server\.hostname=.*$/security.server.hostname=${FQDN}/" ${PROPS_FILE} > /tmp/temp_file
   cp /tmp/temp_file ${PROPS_FILE}
 fi
 
-if [ ! -z ${HTTP_PORT} ]; then
-  cat ${PROPS_FILE} | sed -e "s/^security\.server\.port=.*$/security.server.port=${HTTP_PORT}/" > /tmp/temp_file
+if [ ! -z "${HTTP_PORT}" ]; then
+  sed -e "s/^security\.server\.port=.*$/security.server.port=${HTTP_PORT}/" ${PROPS_FILE} > /tmp/temp_file
   cp /tmp/temp_file ${PROPS_FILE}
 fi
 
-if [ ! -z ${HTTPS_PORT} ]; then
-  cat ${PROPS_FILE} | sed -e "s/^security\.server\.securePort=.*$/security.server.securePort=${HTTPS_PORT}/" > /tmp/temp_file
+if [ ! -z "${HTTPS_PORT}" ]; then
+  sed -e "s/^security\.server\.securePort=.*$/security.server.securePort=${HTTPS_PORT}/" ${PROPS_FILE} > /tmp/temp_file
   cp /tmp/temp_file ${PROPS_FILE}
 fi
 
-if [ ${NET_MODE} = "nat" ]; then
-  cat ${TOMCAT_CONFIG_FILE} | sed -e "s/^.*Connector.*$/    <Connector port=\"80\" protocol=\"HTTP\/1.1\" connectionTimeout=\"20000\" redirectPort=\"443\"\/>/" > /tmp/temp_file
+if [ "${NET_MODE}" = "nat" ]; then
+  sed -e "s/^.*Connector.*$/    <Connector port=\"80\" protocol=\"HTTP\/1.1\" connectionTimeout=\"20000\" redirectPort=\"443\"\/>/" ${TOMCAT_CONFIG_FILE} > /tmp/temp_file
   cp /tmp/temp_file ${TOMCAT_CONFIG_FILE}
 fi
 
-if [ ${NET_MODE} = "bridge" ]; then
-  cat ${TOMCAT_CONFIG_FILE} | sed -e "s/^.*Connector.*$/    <Connector port=\"${HTTP_PORT}\" protocol=\"HTTP\/1.1\" connectionTimeout=\"20000\" redirectPort=\"${HTTPS_PORT}\"\/>/" > /tmp/temp_file
+if [ "${NET_MODE}" = "bridge" ]; then
+  sed -e "s/^.*Connector.*$/    <Connector port=\"${HTTP_PORT}\" protocol=\"HTTP\/1.1\" connectionTimeout=\"20000\" redirectPort=\"${HTTPS_PORT}\"\/>/" ${TOMCAT_CONFIG_FILE} > /tmp/temp_file
   cp /tmp/temp_file ${TOMCAT_CONFIG_FILE}
 fi
 

--- a/packer/ansible/roles/aggregate/files/aggregate-config.sh
+++ b/packer/ansible/roles/aggregate/files/aggregate-config.sh
@@ -63,22 +63,29 @@ if [ "${HELP}" = YES ]; then
   exit 0
 fi
 
-if [ "${NET_MODE}" != "nat" ] && [ "${NET_MODE}" != "bridge" ]; then
-  echo "Error: Invalid --net-mode value. Use 'nat' or 'bridge' according to the VM's networking configuration"
-  echo ""
-  showHelp
-  exit 1
-fi
-
-if [ "${NET_MODE}" == "bridge" ] && ([ -z "${HTTP_PORT}" ] || [ -z "${HTTPS_PORT}" ]); then
-  echo "Error: In net mode 'bridge' you need to provide values for --http-port and --https-port"
-  echo ""
-  showHelp
-  exit 1
-fi
-
 if [ "${HELP}" = NO ] && [ -z "${FQDN}" ] && [ -z "${HTTP_PORT}" ] && [ -z "${HTTPS_PORT}" ]; then
   echo "Error: You need to set at least one argument"
+  echo ""
+  showHelp
+  exit 1
+fi
+
+if ([ ! -z "${HTTP_PORT}" ] && [ -z "${HTTPS_PORT}" ]) || ([ -z "${HTTP_PORT}" ] && [ ! -z "${HTTPS_PORT}" ]); then
+  echo "Error: You need to set both --http-port and --https-port arguments"
+  echo ""
+  showHelp
+  exit 1
+fi
+
+if [ ! -z "${HTTP_PORT}" ] && [ -z "${NET_MODE}" ]; then
+  echo "Error: Setting --net-mode is required with --http-port and --https-port arguments"
+  echo ""
+  showHelp
+  exit 1
+fi
+
+if [ ! -z "${NET_MODE}" ] && [ "${NET_MODE}" != "nat" ] && [ "${NET_MODE}" != "bridge" ]; then
+  echo "Error: Invalid --net-mode value. Use 'nat' or 'bridge' according to the VM's networking configuration"
   echo ""
   showHelp
   exit 1

--- a/packer/ansible/roles/aggregate/files/aggregate-report-ips.sh
+++ b/packer/ansible/roles/aggregate/files/aggregate-report-ips.sh
@@ -5,7 +5,7 @@ rawHostname=$(grep hostname ${propsFile} | awk '{split($0,a,"="); print a[2]}')
 hostname=${rawHostname:-localhost}
 httpPort=$(grep port ${propsFile} | awk '{split($0,a,"="); print a[2]}')
 version=$(cat /usr/local/bin/aggregate-version)
-ips=$(ip address | grep "inet " | grep -v "127.0.0.1" | awk '{print $2}' | awk -F'/' '{print $1}')
+ips=$(hostname -I)
 
 echo "> Welcome to ODK Aggregate VM $version"
 echo "> 1. Open the web browser on your computer"

--- a/packer/ansible/roles/tomcat/files/server.xml
+++ b/packer/ansible/roles/tomcat/files/server.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Server port="8005" shutdown="SHUTDOWN">
-  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
-  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
-  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener"/>
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on"/>
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener"/>
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener"/>
   <GlobalNamingResources>
     <Resource name="UserDatabase" auth="Container"
               type="org.apache.catalina.UserDatabase"
               description="User database that can be updated and saved"
               factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
-              pathname="conf/tomcat-users.xml" />
+              pathname="conf/tomcat-users.xml"/>
   </GlobalNamingResources>
   <Service name="Catalina">
     <Connector port="80" protocol="HTTP/1.1"
                connectionTimeout="20000"
-               redirectPort="443" />
+               redirectPort="443"/>
     <Engine name="Catalina" defaultHost="localhost">
       <Realm className="org.apache.catalina.realm.LockOutRealm">
         <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
                resourceName="UserDatabase"/>
       </Realm>
-      <Host name="localhost"  appBase="webapps"
+      <Host name="localhost" appBase="webapps"
             unpackWARs="true" autoDeploy="true">
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+               pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
       </Host>
     </Engine>
   </Service>

--- a/packer/ansible/roles/tomcat/files/server.xml
+++ b/packer/ansible/roles/tomcat/files/server.xml
@@ -1,168 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-<!-- Note:  A "Server" is not itself a "Container", so you may not
-     define subcomponents such as "Valves" at this level.
-     Documentation at /docs/config/server.html
- -->
 <Server port="8005" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
-  <!-- Security listener. Documentation at /docs/config/listeners.html
-  <Listener className="org.apache.catalina.security.SecurityListener" />
-  -->
-  <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
-
-  <!-- Global JNDI resources
-       Documentation at /docs/jndi-resources-howto.html
-  -->
   <GlobalNamingResources>
-    <!-- Editable user database that can also be used by
-         UserDatabaseRealm to authenticate users
-    -->
     <Resource name="UserDatabase" auth="Container"
               type="org.apache.catalina.UserDatabase"
               description="User database that can be updated and saved"
               factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
               pathname="conf/tomcat-users.xml" />
   </GlobalNamingResources>
-
-  <!-- A "Service" is a collection of one or more "Connectors" that share
-       a single "Container" Note:  A "Service" is not itself a "Container",
-       so you may not define subcomponents such as "Valves" at this level.
-       Documentation at /docs/config/service.html
-   -->
   <Service name="Catalina">
-
-    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
-    <!--
-    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
-        maxThreads="150" minSpareThreads="4"/>
-    -->
-
-
-    <!-- A "Connector" represents an endpoint by which requests are received
-         and responses are returned. Documentation at :
-         Java HTTP Connector: /docs/config/http.html
-         Java AJP  Connector: /docs/config/ajp.html
-         APR (HTTP/AJP) Connector: /docs/apr.html
-         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
-    -->
     <Connector port="80" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="443" />
-    <!-- A "Connector" using the shared thread pool-->
-    <!--
-    <Connector executor="tomcatThreadPool"
-               port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               redirectPort="8443" />
-    -->
-    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
-         This connector uses the NIO implementation. The default
-         SSLImplementation will depend on the presence of the APR/native
-         library and the useOpenSSL attribute of the
-         AprLifecycleListener.
-         Either JSSE or OpenSSL style configuration may be used regardless of
-         the SSLImplementation selected. JSSE style configuration is used below.
-    -->
-    <!--
-    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
-               maxThreads="150" SSLEnabled="true">
-        <SSLHostConfig>
-            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
-                         type="RSA" />
-        </SSLHostConfig>
-    </Connector>
-    -->
-    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
-         This connector uses the APR/native implementation which always uses
-         OpenSSL for TLS.
-         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
-         configuration is used below.
-    -->
-    <!--
-    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
-               maxThreads="150" SSLEnabled="true" >
-        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
-        <SSLHostConfig>
-            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
-                         certificateFile="conf/localhost-rsa-cert.pem"
-                         certificateChainFile="conf/localhost-rsa-chain.pem"
-                         type="RSA" />
-        </SSLHostConfig>
-    </Connector>
-    -->
-
-    <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <!--
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
-    -->
-
-
-    <!-- An Engine represents the entry point (within Catalina) that processes
-         every request.  The Engine implementation for Tomcat stand alone
-         analyzes the HTTP headers included with the request, and passes them
-         on to the appropriate Host (virtual host).
-         Documentation at /docs/config/engine.html -->
-
-    <!-- You should set jvmRoute to support load-balancing via AJP ie :
-    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
-    -->
     <Engine name="Catalina" defaultHost="localhost">
-
-      <!--For clustering, please take a look at documentation at:
-          /docs/cluster-howto.html  (simple how to)
-          /docs/config/cluster.html (reference documentation) -->
-      <!--
-      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
-      -->
-
-      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
-           via a brute-force attack -->
       <Realm className="org.apache.catalina.realm.LockOutRealm">
-        <!-- This Realm uses the UserDatabase configured in the global JNDI
-             resources under the key "UserDatabase".  Any edits
-             that are performed against this UserDatabase are immediately
-             available for use by the Realm.  -->
         <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
                resourceName="UserDatabase"/>
       </Realm>
-
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
-
-        <!-- SingleSignOn valve, share authentication between web applications
-             Documentation at: /docs/config/valve.html -->
-        <!--
-        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
-        -->
-
-        <!-- Access log processes all example.
-             Documentation at: /docs/config/valve.html
-             Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
-
       </Host>
     </Engine>
   </Service>

--- a/packer/ansible/roles/tomcat/files/server.xml
+++ b/packer/ansible/roles/tomcat/files/server.xml
@@ -6,26 +6,16 @@
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener"/>
   <GlobalNamingResources>
-    <Resource name="UserDatabase" auth="Container"
-              type="org.apache.catalina.UserDatabase"
-              description="User database that can be updated and saved"
-              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
-              pathname="conf/tomcat-users.xml"/>
+    <Resource name="UserDatabase" auth="Container" type="org.apache.catalina.UserDatabase" description="User database that can be updated and saved" factory="org.apache.catalina.users.MemoryUserDatabaseFactory" pathname="conf/tomcat-users.xml"/>
   </GlobalNamingResources>
   <Service name="Catalina">
-    <Connector port="80" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               redirectPort="443"/>
+    <Connector port="80" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="443"/>
     <Engine name="Catalina" defaultHost="localhost">
       <Realm className="org.apache.catalina.realm.LockOutRealm">
-        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
-               resourceName="UserDatabase"/>
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm" resourceName="UserDatabase"/>
       </Realm>
-      <Host name="localhost" appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log" suffix=".txt"
-               pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
+      <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs" prefix="localhost_access_log" suffix=".txt" pattern="%h %l %u %t &quot;%r&quot; %s %b"/>
       </Host>
     </Engine>
   </Service>

--- a/packer/ansible/roles/tomcat/files/server.xml.original
+++ b/packer/ansible/roles/tomcat/files/server.xml.original
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="80" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!--
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    -->
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/packer/ansible/roles/tomcat/tasks/main.yml
+++ b/packer/ansible/roles/tomcat/tasks/main.yml
@@ -16,6 +16,13 @@
     group: tomcat8
     mode: 0640
 
+- name: copy server.xml.original
+  copy:
+    src: server.xml.original
+    dest: /etc/tomcat8/server.xml.original
+    group: tomcat8
+    mode: 0640
+
 - name: copy tomcat8
   copy: 
     src: tomcat8


### PR DESCRIPTION
Closes #312

This PR improves the `aggregate-config` tool that we ship in the Aggregate VM:
- Added a new `--net-mode` argument that will accept either `nat` or `bridge` values to adapt Tomcat's and Aggregate's configuration to the current VM network device mode.

This PR also simplifies the shell command to get the IP addresses on the VM for the MOTD.

#### What has been done to verify that this works as intended?
Run the commands in the VM, having changed back and forth the network device. Verified that Aggregate was reachable in both nat and bridge scenarios.

#### Why is this the best possible solution? Were any other approaches considered?
No other approaches considered for this change. 

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
https://github.com/opendatakit/docs/issues/866