### PR TITLE
Security fixes batch 3

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminService.java
@@ -54,6 +54,7 @@ public interface ServicesAdminService extends RemoteService {
   @XsrfProtect
   String createRedCapServer(String formId, String apiKey, String url, ExternalServicePublicationOption esOption, String ownerEmail) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   Boolean deletePublisher(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/externalserv/ServicesAdminServiceAsync.java
@@ -24,22 +24,15 @@ public interface ServicesAdminServiceAsync {
 
   void getExternalServices(String formid, AsyncCallback<ExternServSummary[]> callback);
 
-  void createFusionTable(String formId, ExternalServicePublicationOption esOption,
-                         String ownerEmail, AsyncCallback<String> callback);
+  void createFusionTable(String formId, ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
 
-  void createGoogleSpreadsheet(String formId, String name,
-                               ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
+  void createGoogleSpreadsheet(String formId, String name, ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
 
-  void createSimpleJsonServer(String formId, String authKey, String url,
-                              ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption,
-                              AsyncCallback<String> callback);
+  void createSimpleJsonServer(String formId, String authKey, String url, ExternalServicePublicationOption es, String ownerEmail, BinaryOption binaryOption, AsyncCallback<String> callback);
 
-  void createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp,
-                              String user, String hashedPassword, String url, ExternalServicePublicationOption es,
-                              String ownerEmail, AsyncCallback<String> callback);
+  void createOhmageJsonServer(String formId, String campaignUrn, String campaignTimestamp, String user, String hashedPassword, String url, ExternalServicePublicationOption es, String ownerEmail, AsyncCallback<String> callback);
 
-  void createRedCapServer(String formId, String apiKey, String url,
-                          ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
+  void createRedCapServer(String formId, String apiKey, String url, ExternalServicePublicationOption esOption, String ownerEmail, AsyncCallback<String> callback);
 
   void deletePublisher(String uri, AsyncCallback<Boolean> callback);
 

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -38,6 +38,7 @@ import org.opendatakit.common.security.client.exception.AccessDeniedException;
 @RemoteServiceRelativePath("formadminservice")
 public interface FormAdminService extends RemoteService {
 
+  @XsrfProtect
   void setFormDownloadable(String formId, Boolean downloadable) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -40,6 +40,7 @@ public interface FormAdminService extends RemoteService {
 
   void setFormDownloadable(String formId, Boolean downloadable) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminService.java
@@ -54,6 +54,7 @@ public interface FormAdminService extends RemoteService {
 
   SubmissionUISummary getIncompleteSubmissions(FilterGroup filter) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
+  @XsrfProtect
   void markSubmissionAsComplete(String submissionKeyAsString) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;
 
   ArrayList<MediaFileSummary> getFormMediaFileList(String formId) throws AccessDeniedException, DatastoreFailureException, RequestFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormAdminServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormAdminServiceAsync.java
@@ -16,13 +16,11 @@
 
 package org.opendatakit.aggregate.client.form;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import java.util.ArrayList;
 import java.util.Date;
-
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.client.submission.SubmissionUISummary;
-
-import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public interface FormAdminServiceAsync {
 
@@ -30,8 +28,7 @@ public interface FormAdminServiceAsync {
 
   void purgePublishedData(String uriExternalService, Date earliest, AsyncCallback<Date> callback);
 
-  void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions,
-      AsyncCallback<Void> callback);
+  void setFormAcceptSubmissions(String formId, Boolean acceptSubmissions, AsyncCallback<Void> callback);
 
   void setFormDownloadable(String formId, Boolean downloadable, AsyncCallback<Void> callback);
 

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormService.java
@@ -52,5 +52,6 @@ public interface FormService extends RemoteService {
 
   GeopointElementList getGpsCoordnates(String formId) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void deleteExport(String uri) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/form/FormServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/form/FormServiceAsync.java
@@ -32,8 +32,7 @@ public interface FormServiceAsync {
 
   void createCsvFromFilter(FilterGroup group, AsyncCallback<Boolean> callback);
 
-  void createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude,
-                           AsyncCallback<Boolean> callback);
+  void createKmlFromFilter(FilterGroup group, ArrayList<KmlSelection> kmlElementsToInclude, AsyncCallback<Boolean> callback);
 
   void createJsonFileFromFilter(FilterGroup group, AsyncCallback<Boolean> callback);
 

--- a/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
@@ -33,6 +33,7 @@ import org.opendatakit.common.security.client.exception.AccessDeniedException;
 public interface PreferenceService extends RemoteService {
   PreferenceSummary getPreferences() throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void setSkipMalformedSubmissions(Boolean skipMalformedSubmissions) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   void setFasterBackgroundActionsDisabled(Boolean disabled) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;

--- a/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
@@ -36,6 +36,7 @@ public interface PreferenceService extends RemoteService {
   @XsrfProtect
   void setSkipMalformedSubmissions(Boolean skipMalformedSubmissions) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void setFasterBackgroundActionsDisabled(Boolean disabled) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
   @XsrfProtect

--- a/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
@@ -16,19 +16,18 @@
 
 package org.opendatakit.aggregate.client.preferences;
 
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+import com.google.gwt.user.server.rpc.XsrfProtect;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
 import org.opendatakit.common.persistence.client.exception.DatastoreFailureException;
 import org.opendatakit.common.security.client.exception.AccessDeniedException;
-
-import com.google.gwt.user.client.rpc.RemoteService;
-import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
 /**
  * These actions require the ROLE_USER privilege, which is the least capable
  * privilege (granted to all authorized users of the system).
  *
  * @author wbrunette@gmail.com
- *
  */
 @RemoteServiceRelativePath("preferenceservice")
 public interface PreferenceService extends RemoteService {
@@ -38,7 +37,8 @@ public interface PreferenceService extends RemoteService {
 
   void setFasterBackgroundActionsDisabled(Boolean disabled) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void setOdkTablesEnabled(Boolean enabled) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
-  
-  void setOdkAppName(String appName) throws AccessDeniedException, RequestFailureException, DatastoreFailureException; 
+
+  void setOdkAppName(String appName) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
@@ -40,5 +40,6 @@ public interface PreferenceService extends RemoteService {
   @XsrfProtect
   void setOdkTablesEnabled(Boolean enabled) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 
+  @XsrfProtect
   void setOdkAppName(String appName) throws AccessDeniedException, RequestFailureException, DatastoreFailureException;
 }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/DisableFasterBackgroundActionsCheckbox.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/DisableFasterBackgroundActionsCheckbox.java
@@ -16,23 +16,21 @@
 
 package org.opendatakit.aggregate.client.widgets;
 
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
+import static org.opendatakit.common.security.common.GrantedAuthorityName.ROLE_SITE_ACCESS_ADMIN;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.preferences.Preferences;
 import org.opendatakit.aggregate.client.preferences.Preferences.PreferencesCompletionCallback;
-import org.opendatakit.common.security.common.GrantedAuthorityName;
 
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-
-public final class DisableFasterBackgroundActionsCheckbox extends AggregateCheckBox implements
-    ValueChangeHandler<Boolean> {
+public final class DisableFasterBackgroundActionsCheckbox extends AggregateCheckBox implements ValueChangeHandler<Boolean> {
 
   private static final String LABEL = "Disable faster background actions (exports, publishing, form deletion) (slows quota usage on Google AppEngine)";
   private static final String TOOLTIP_TXT = "Enable/Disable Faster Background Actions";
-  private static final String HELP_BALLOON_TXT = "Check this box if you need to preserve Google AppEngine quota for submissions and website activities. "
-      + "Otherwise leave unchecked. If checked, exports, publishing and form deletion requests will take longer to complete.";
+  private static final String HELP_BALLOON_TXT = "Check this box if you need to preserve Google AppEngine quota for submissions and website activities. Otherwise leave unchecked. If checked, exports, publishing and form deletion requests will take longer to complete.";
 
   private PreferencesCompletionCallback settingsChange;
 
@@ -40,36 +38,35 @@ public final class DisableFasterBackgroundActionsCheckbox extends AggregateCheck
     super(LABEL, false, TOOLTIP_TXT, HELP_BALLOON_TXT);
     this.settingsChange = settingsChange;
     setValue(enabled);
-    boolean accessible = AggregateUI.getUI().getUserInfo().getGrantedAuthorities()
-        .contains(GrantedAuthorityName.ROLE_SITE_ACCESS_ADMIN);
+    boolean accessible = AggregateUI.getUI().getUserInfo().getGrantedAuthorities().contains(ROLE_SITE_ACCESS_ADMIN);
     setEnabled(accessible);
   }
 
   public void updateValue(Boolean value) {
     Boolean currentValue = getValue();
-    if (currentValue != value) {
+    if (currentValue != value)
       setValue(value);
-    }
   }
 
   @Override
   public void onValueChange(ValueChangeEvent<Boolean> event) {
     super.onValueChange(event);
+    secureRequest(
+        SecureGWT.getPreferenceService(),
+        (rpc, sessionCookie, cb) -> rpc.setFasterBackgroundActionsDisabled(event.getValue(), cb),
+        this::onSuccess,
+        this::onError
+    );
+  }
 
-    final Boolean enabled = event.getValue();
-    SecureGWT.getPreferenceService().setFasterBackgroundActionsDisabled(enabled, new AsyncCallback<Void>() {
-      @Override
-      public void onFailure(Throwable caught) {
-        // restore old value
-        setValue(Preferences.getFasterBackgroundActionsDisabled());
-        AggregateUI.getUI().reportError(caught);
-      }
+  private void onError(Throwable cause) {
+    // restore old value
+    setValue(Preferences.getFasterBackgroundActionsDisabled());
+    AggregateUI.getUI().reportError(cause);
+  }
 
-      @Override
-      public void onSuccess(Void result) {
-        AggregateUI.getUI().clearError();
-        Preferences.updatePreferences(settingsChange);
-      }
-    });
+  private void onSuccess() {
+    AggregateUI.getUI().clearError();
+    Preferences.updatePreferences(settingsChange);
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/DownloadableCheckBox.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/DownloadableCheckBox.java
@@ -16,20 +16,18 @@
 
 package org.opendatakit.aggregate.client.widgets;
 
-import org.opendatakit.aggregate.client.AggregateUI;
-import org.opendatakit.aggregate.client.SecureGWT;
-import org.opendatakit.common.security.common.GrantedAuthorityName;
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
+import static org.opendatakit.common.security.common.GrantedAuthorityName.ROLE_DATA_OWNER;
 
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.opendatakit.aggregate.client.AggregateUI;
+import org.opendatakit.aggregate.client.SecureGWT;
 
-public final class DownloadableCheckBox extends AggregateCheckBox implements
-    ValueChangeHandler<Boolean> {
+public final class DownloadableCheckBox extends AggregateCheckBox implements ValueChangeHandler<Boolean> {
 
   private static final String TOOLTIP_TXT = "Allow or disallow form to be downloaded";
-  private static final String HELP_BALLOON_TXT = "Check this box if you want your form to be "
-      + "downloadable.  Otherwise leave unchecked.";
+  private static final String HELP_BALLOON_TXT = "Check this box if you want your form to be downloadable. Otherwise leave unchecked.";
 
   private final String formId;
 
@@ -37,27 +35,26 @@ public final class DownloadableCheckBox extends AggregateCheckBox implements
     super(null, false, TOOLTIP_TXT, HELP_BALLOON_TXT);
     this.formId = formId;
     setValue(downloadable);
-    boolean enabled = AggregateUI.getUI().getUserInfo().getGrantedAuthorities()
-        .contains(GrantedAuthorityName.ROLE_DATA_OWNER);
+    boolean enabled = AggregateUI.getUI().getUserInfo().getGrantedAuthorities().contains(ROLE_DATA_OWNER);
     setEnabled(enabled);
   }
 
   @Override
   public void onValueChange(ValueChangeEvent<Boolean> event) {
     super.onValueChange(event);
-   
-    SecureGWT.getFormAdminService().setFormDownloadable(formId, event.getValue(),
-        new AsyncCallback<Void>() {
-          @Override
-          public void onFailure(Throwable caught) {
-            AggregateUI.getUI().reportError(caught);
-          }
-
-          @Override
-          public void onSuccess(Void v) {
-            AggregateUI.getUI().clearError();
-          }
-        });
+    secureRequest(
+        SecureGWT.getFormAdminService(),
+        (rpc, sessionCookie, cb) -> rpc.setFormDownloadable(formId, event.getValue(), cb),
+        this::onSuccess,
+        this::onError
+    );
   }
 
+  private void onError(Throwable cause) {
+    AggregateUI.getUI().reportError(cause);
+  }
+
+  private void onSuccess() {
+    AggregateUI.getUI().clearError();
+  }
 }

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/MarkSubmissionCompleteButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/MarkSubmissionCompleteButton.java
@@ -16,12 +16,12 @@
 
 package org.opendatakit.aggregate.client.widgets;
 
-import org.opendatakit.aggregate.client.AggregateUI;
-import org.opendatakit.aggregate.client.SecureGWT;
+import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequest;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.opendatakit.aggregate.client.AggregateUI;
+import org.opendatakit.aggregate.client.SecureGWT;
 
 public class MarkSubmissionCompleteButton extends AggregateButton implements ClickHandler {
 
@@ -40,22 +40,20 @@ public class MarkSubmissionCompleteButton extends AggregateButton implements Cli
   @Override
   public void onClick(ClickEvent event) {
     super.onClick(event);
-
-    // Set up the callback object.
-    AsyncCallback<Void> callback = new AsyncCallback<Void>() {
-      @Override
-      public void onFailure(Throwable caught) {
-        AggregateUI.getUI().reportError(caught);
-      }
-
-      @Override
-      public void onSuccess(Void result) {
-        AggregateUI.getUI().clearError();
-        AggregateUI.getUI().getTimer().refreshNow();
-      }
-    };
-    // Make the call to the form service.
-    SecureGWT.getFormAdminService().markSubmissionAsComplete(submissionKeyAsString, callback);
+    secureRequest(
+        SecureGWT.getFormAdminService(),
+        (rpc, sessionCookie, cb) -> rpc.markSubmissionAsComplete(submissionKeyAsString, cb),
+        this::onSuccess,
+        this::onError
+    );
   }
 
+  private void onError(Throwable cause) {
+    AggregateUI.getUI().reportError(cause);
+  }
+
+  private void onSuccess() {
+    AggregateUI.getUI().clearError();
+    AggregateUI.getUI().getTimer().refreshNow();
+  }
 }


### PR DESCRIPTION
This PR adds extra security protections to some RPC calls:
- Enable accept submissions on form
- Mark submission as complete 
- Enable downloading a form
- Delete exported form
- Delete publisher
- Enable ODK Tables 
- Set ODK App name
- Set skip malformed Submissions

#### What has been done to verify that this works as intended?
This a follow up on #303 and #308

#### Why is this the best possible solution? Were any other approaches considered?
See #303 and #308

#### Are there any risks to merging this code? If so, what are they?
Any third party hitting these RPCs will have to request a CSRF token before making them. 

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.