### PR TITLE
Add note warning about a new Aggregate version

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/ExportSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/ExportSubTab.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client;
 
+import static org.opendatakit.aggregate.client.LayoutUtils.buildVersionNote;
+
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.form.ExportSummary;
@@ -37,6 +39,7 @@ public class ExportSubTab extends AggregateSubTabBase {
 
     exportTable = new ExportTable();
     add(exportTable);
+    add(buildVersionNote());
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/client/FiltersDataPanel.java
+++ b/src/main/java/org/opendatakit/aggregate/client/FiltersDataPanel.java
@@ -16,7 +16,8 @@
 
 package org.opendatakit.aggregate.client;
 
-import com.google.gwt.dom.client.Style;
+import static org.opendatakit.aggregate.client.LayoutUtils.*;
+
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
@@ -28,7 +29,6 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import org.opendatakit.aggregate.buildconfig.BuildConfig;
 import org.opendatakit.aggregate.client.filter.ColumnFilter;
 import org.opendatakit.aggregate.client.filter.Filter;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
@@ -90,34 +90,13 @@ public class FiltersDataPanel extends ScrollPanel {
     filtersTree = new Tree();
     panel.add(filtersTree);
 
-    String latestVersion = getLatestVersion();
-    boolean needsUpdate = !BuildConfig.VERSION.startsWith(latestVersion);
-    HTML versionNote = new HTML("" +
-        "<small>ODK Aggregate " + BuildConfig.VERSION + "<br/>" +
-        (needsUpdate
-            ? "Update available: <a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">" + latestVersion + "</a>"
-            : "You're up to date"
-        ) +
-        "</small>");
-    Style style = versionNote.getElement().getStyle();
-    style.setProperty("position", "fixed");
-    style.setProperty("bottom", "10px");
-    style.setProperty("left", "10px");
-    panel.add(versionNote);
+    panel.add(buildVersionNote());
 
     // create the root as the new filter button
     addFilter = new AddFilterButton(parentPanel);
 
     add(panel);
   }
-
-  private native String getLatestVersion() /*-{
-    var req = new XMLHttpRequest();
-    req.open('GET', 'https://api.github.com/repos/opendatakit/aggregate/releases/latest', false);
-    req.send(null);
-    if (req.readyState === 4 && req.status === 200)
-      return JSON.parse(req.responseText).tag_name;
-  }-*/;
 
   public void update(FilterGroup group) {
     // check if filter group has changed

--- a/src/main/java/org/opendatakit/aggregate/client/FiltersDataPanel.java
+++ b/src/main/java/org/opendatakit/aggregate/client/FiltersDataPanel.java
@@ -16,10 +16,19 @@
 
 package org.opendatakit.aggregate.client;
 
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.Tree;
+import com.google.gwt.user.client.ui.TreeItem;
+import com.google.gwt.user.client.ui.VerticalPanel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
+import org.opendatakit.aggregate.buildconfig.BuildConfig;
 import org.opendatakit.aggregate.client.filter.ColumnFilter;
 import org.opendatakit.aggregate.client.filter.Filter;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
@@ -33,15 +42,6 @@ import org.opendatakit.aggregate.client.widgets.RemoveFilterGroupButton;
 import org.opendatakit.aggregate.client.widgets.SaveAsFilterGroupButton;
 import org.opendatakit.aggregate.client.widgets.SaveFilterGroupButton;
 import org.opendatakit.aggregate.constants.common.UIConsts;
-
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.ScrollPanel;
-import com.google.gwt.user.client.ui.Tree;
-import com.google.gwt.user.client.ui.TreeItem;
-import com.google.gwt.user.client.ui.VerticalPanel;
 
 public class FiltersDataPanel extends ScrollPanel {
 
@@ -62,8 +62,7 @@ public class FiltersDataPanel extends ScrollPanel {
     getElement().setId("filters_container");
 
     FlowPanel panel = new FlowPanel();
-   // panel.add( new HTML("<h2 id=\"filter_header\">" + HtmlConsts.SPACE + "Filters</h2>"));
-  
+
     FlexTable filterGroupButtons = new FlexTable();
     filterGroupButtons.setWidget(0, 0, new SaveFilterGroupButton(parentSubTab));
     copyButton = new SaveAsFilterGroupButton(parentSubTab);
@@ -91,11 +90,34 @@ public class FiltersDataPanel extends ScrollPanel {
     filtersTree = new Tree();
     panel.add(filtersTree);
 
+    String latestVersion = getLatestVersion();
+    boolean needsUpdate = !BuildConfig.VERSION.startsWith(latestVersion);
+    HTML versionNote = new HTML("" +
+        "<small>ODK Aggregate " + BuildConfig.VERSION + "<br/>" +
+        (needsUpdate
+            ? "Update available: <a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">" + latestVersion + "</a>"
+            : "You're up to date"
+        ) +
+        "</small>");
+    Style style = versionNote.getElement().getStyle();
+    style.setProperty("position", "fixed");
+    style.setProperty("bottom", "10px");
+    style.setProperty("left", "10px");
+    panel.add(versionNote);
+
     // create the root as the new filter button
     addFilter = new AddFilterButton(parentPanel);
 
     add(panel);
   }
+
+  private native String getLatestVersion() /*-{
+    var req = new XMLHttpRequest();
+    req.open('GET', 'https://api.github.com/repos/opendatakit/aggregate/releases/latest', false);
+    req.send(null);
+    if (req.readyState === 4 && req.status === 200)
+      return JSON.parse(req.responseText).tag_name;
+  }-*/;
 
   public void update(FilterGroup group) {
     // check if filter group has changed

--- a/src/main/java/org/opendatakit/aggregate/client/FormsSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/FormsSubTab.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client;
 
+import static org.opendatakit.aggregate.client.LayoutUtils.buildVersionNote;
+
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.form.FormSummary;
@@ -60,6 +62,7 @@ public class FormsSubTab extends AggregateSubTabBase {
     // add tables to panels
     add(newForm);
     add(listOfForms);
+    add(buildVersionNote());
 
   }
 

--- a/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
@@ -1,0 +1,35 @@
+package org.opendatakit.aggregate.client;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.ui.HTML;
+import org.opendatakit.aggregate.buildconfig.BuildConfig;
+
+public class LayoutUtils {
+  private static String latestVersion;
+
+  static native String getLatestVersion() /*-{
+    var req = new XMLHttpRequest();
+    req.open('GET', 'https://api.github.com/repos/opendatakit/aggregate/releases/latest', false);
+    req.send(null);
+    if (req.readyState === 4 && req.status === 200)
+      return JSON.parse(req.responseText).tag_name;
+  }-*/;
+
+  static HTML buildVersionNote() {
+    if (latestVersion == null)
+      latestVersion = getLatestVersion();
+    boolean needsUpdate = !BuildConfig.VERSION.startsWith(latestVersion);
+    HTML versionNote = new HTML("" +
+        "<small>ODK Aggregate " + BuildConfig.VERSION + "<br/>" +
+        (needsUpdate
+            ? "Update available: <a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">" + latestVersion + "</a>"
+            : "You're up to date"
+        ) +
+        "</small>");
+    Style style = versionNote.getElement().getStyle();
+    style.setProperty("position", "fixed");
+    style.setProperty("bottom", "10px");
+    style.setProperty("left", "10px");
+    return versionNote;
+  }
+}

--- a/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
@@ -26,8 +26,10 @@ public class LayoutUtils {
     HTML html = new HTML("<small>" + shortVersion + " - " + versionNote + "</small>");
     Style style = html.getElement().getStyle();
     style.setProperty("position", "fixed");
-    style.setProperty("bottom", "10px");
-    style.setProperty("left", "10px");
+    style.setProperty("bottom", "0");
+    style.setProperty("left", "0");
+    style.setProperty("padding", "5px 10px");
+    style.setProperty("backgroundColor", "rgba(255,255,255,.9)");
     return html;
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
@@ -1,8 +1,9 @@
 package org.opendatakit.aggregate.client;
 
+import static org.opendatakit.aggregate.buildconfig.BuildConfig.VERSION;
+
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.HTML;
-import org.opendatakit.aggregate.buildconfig.BuildConfig;
 
 public class LayoutUtils {
   private static String latestVersion;
@@ -18,18 +19,15 @@ public class LayoutUtils {
   static HTML buildVersionNote() {
     if (latestVersion == null)
       latestVersion = getLatestVersion();
-    boolean needsUpdate = !BuildConfig.VERSION.startsWith(latestVersion);
-    HTML versionNote = new HTML("" +
-        "<small>ODK Aggregate " + BuildConfig.VERSION + "<br/>" +
-        (needsUpdate
-            ? "Update available: <a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">" + latestVersion + "</a>"
-            : "You're up to date"
-        ) +
-        "</small>");
-    Style style = versionNote.getElement().getStyle();
+    String shortVersion = VERSION.contains("-") ? VERSION.substring(0, VERSION.indexOf("-")) : VERSION;
+    String versionNote = shortVersion.equals(latestVersion)
+        ? "You're up to date!"
+        : "<a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">Update available</a>";
+    HTML html = new HTML("<small>" + shortVersion + " - " + versionNote + "</small>");
+    Style style = html.getElement().getStyle();
     style.setProperty("position", "fixed");
     style.setProperty("bottom", "10px");
     style.setProperty("left", "10px");
-    return versionNote;
+    return html;
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/client/PermissionsSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/PermissionsSubTab.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client;
 
+import static org.opendatakit.aggregate.client.LayoutUtils.buildVersionNote;
+
 import org.opendatakit.aggregate.client.permissions.AccessConfigurationSheet;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.opendatakit.common.security.common.GrantedAuthorityName;
@@ -58,6 +60,7 @@ public class PermissionsSubTab extends AggregateSubTabBase {
         if ( accessConfig == null ) {
             accessConfig = new AccessConfigurationSheet(this);
             add(accessConfig);
+            add(buildVersionNote());
         }
         accessConfig.setVisible(true);
     } else {

--- a/src/main/java/org/opendatakit/aggregate/client/PreferencesSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/PreferencesSubTab.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client;
 
+import static org.opendatakit.aggregate.client.LayoutUtils.buildVersionNote;
+
 import org.opendatakit.aggregate.buildconfig.BuildConfig;
 import org.opendatakit.aggregate.client.preferences.Preferences;
 import org.opendatakit.aggregate.client.preferences.Preferences.PreferencesCompletionCallback;
@@ -236,6 +238,8 @@ public class PreferencesSubTab extends AggregateSubTabBase {
     skipMalformedSubmissions = new SkipMalformedSubmissionsCheckbox(
         Preferences.getSkipMalformedSubmissions(), settingsChange);
     add(skipMalformedSubmissions);
+
+    add(buildVersionNote());
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/client/PublishSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/PublishSubTab.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client;
 
+import static org.opendatakit.aggregate.client.LayoutUtils.buildVersionNote;
+
 import java.util.ArrayList;
 
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
@@ -57,6 +59,7 @@ public class PublishSubTab extends AggregateSubTabBase {
     // add tables to panels
     add(navTable);
     add(publishTable);
+    add(buildVersionNote());
   }
 
 

--- a/src/main/java/org/opendatakit/aggregate/client/SubmissionAdminSubTab.java
+++ b/src/main/java/org/opendatakit/aggregate/client/SubmissionAdminSubTab.java
@@ -16,8 +16,15 @@
 
 package org.opendatakit.aggregate.client;
 
-import java.util.ArrayList;
+import static org.opendatakit.aggregate.client.LayoutUtils.buildVersionNote;
 
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import java.util.ArrayList;
 import org.opendatakit.aggregate.client.filter.FilterGroup;
 import org.opendatakit.aggregate.client.form.FormServiceAsync;
 import org.opendatakit.aggregate.client.form.FormSummary;
@@ -29,13 +36,6 @@ import org.opendatakit.aggregate.client.widgets.ServletPopupButton;
 import org.opendatakit.aggregate.constants.common.HelpSliderConsts;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.opendatakit.common.security.common.GrantedAuthorityName;
-
-import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.FlexTable;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.ScrollPanel;
 
 public class SubmissionAdminSubTab extends AggregateSubTabBase {
 
@@ -78,12 +78,13 @@ public class SubmissionAdminSubTab extends AggregateSubTabBase {
     add(navTable);
     add(new Label("Incomplete Submissions:"));
     add(submissions);
+    add(buildVersionNote());
   }
 
 
   @Override
   public boolean canLeave() {
-     return true;
+    return true;
   }
 
   private class UpdateAction implements AsyncCallback<ArrayList<FormSummary>> {
@@ -103,17 +104,19 @@ public class SubmissionAdminSubTab extends AggregateSubTabBase {
       // Make the call to get the published services
       updateContent();
     }
-  };
+  }
+
+  ;
 
   @Override
   public void update() {
-    if ( AggregateUI.getUI().getUserInfo().getGrantedAuthorities().contains(GrantedAuthorityName.ROLE_DATA_OWNER)) {
+    if (AggregateUI.getUI().getUserInfo().getGrantedAuthorities().contains(GrantedAuthorityName.ROLE_DATA_OWNER)) {
       formsBox.setVisible(true);
       submissions.setVisible(true);
-       FormServiceAsync formSvc = SecureGWT.getFormService();
+      FormServiceAsync formSvc = SecureGWT.getFormService();
 
-       // Make the call to the form service.
-       formSvc.getForms(new UpdateAction());
+      // Make the call to the form service.
+      formSvc.getForms(new UpdateAction());
     } else {
       formsBox.setVisible(false);
       submissions.setVisible(false);
@@ -153,13 +156,12 @@ public class SubmissionAdminSubTab extends AggregateSubTabBase {
 
   /**
    * Handler to process the change in the form drop down
-   *
    */
   private class ChangeDropDownHandler implements ChangeHandler {
     @Override
     public void onChange(ChangeEvent event) {
       FormSummary form = formsBox.getSelectedForm();
-      if(form != null) {
+      if (form != null) {
         selectedForm = form;
       }
       updateContent();


### PR DESCRIPTION
This PR attempts to give users a heads up about the availability of a newer Aggregate version.

A new note will appear on the Filters tab at the bottom left indicating the current version and a link if there's a newer version available. Otherwise, it tells the user that they're "up to date".

![image](https://user-images.githubusercontent.com/205913/46699179-4c3b3f00-cc19-11e8-93c1-912a7a713733.png)

#### What has been done to verify that this works as intended?
Run on my dev server and verified that both messages where correctly being shown.

#### Why is this the best possible solution? Were any other approaches considered?
It's a very narrow implementation, trying to have minimal impact on the layout

It's, by the way, the most cross-browser, backwards-compatible JS code I've written in my life:

```js
var req = new XMLHttpRequest();
req.open('GET', 'https://api.github.com/repos/opendatakit/aggregate/releases/latest', false);
req.send(null);
if (req.readyState === 4 && req.status === 200)
  return JSON.parse(req.responseText).tag_name;
```
(Notice that old-school `XMLHttpRequest`! It's even synchronous!)
#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
None.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.