### PR TITLE
Warn users of upcoming deprecation

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/constants/common/ExternalServiceType.java
+++ b/src/main/java/org/opendatakit/aggregate/constants/common/ExternalServiceType.java
@@ -29,9 +29,9 @@ import java.io.Serializable;
 public enum ExternalServiceType implements Serializable {
   GOOGLE_SPREADSHEET("Google Spreadsheet"),
   JSON_SERVER("Z-ALPHA JSON Server"),
-  OHMAGE_JSON_SERVER("Z-ALPHA Ohmage JSON Server"),
+  OHMAGE_JSON_SERVER("Z-ALPHA Ohmage JSON Server (To be removed in v2.0)"),
   GOOGLE_FUSIONTABLES( "Google FusionTables"),
-  REDCAP_SERVER("Z-ALPHA REDCap Server"),
+  REDCAP_SERVER("Z-ALPHA REDCap Server (To be removed in v2.0)"),
   GOOGLE_MAPS_ENGINE("Z-OBSOLETE Google Maps Engine");
 
   private String serviceName;


### PR DESCRIPTION
Address #290

#### What has been done to verify that this works as intended?
Ran the app and confirmed the publish dropdown is there in Submissions tab. Also confirmed that publisher types in Published Data showed up.

I did not try this with an install with an existing publisher so it'd be good to test that users that upgrade won't be harmed.

#### Why is this the best possible solution? Were any other approaches considered?
Just a targeted text change.

#### Are there any risks to merging this code? If so, what are they?
There might be people who use the text of this drop down to do things, but given that these publishers don't work, it's unlikely.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Not yet. After we deprecate in v2.0 then we should update the docs. 