### PR TITLE
Bump JR version to 2.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ def versions = [
     gson          : '2.8.0',
     kxml2         : '2.3.0',
     odk           : [
-        javarosa     : '2.11.0',
+        javarosa     : '2.12.1',
         httpclientGae: '4.5.2-1',
         tomcatUtil   : '1.0.1'
     ],


### PR DESCRIPTION
This PR bumps the JavaRosa dependency to 2.12.1-SNAPSHOT, which includes a hotfix to support dynamic `randomize()` seeds.