### PR TITLE
Format dates with ISO_LOCAL_DATE formatter to avoid non-parseable values

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRDateType.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRDateType.java
@@ -69,7 +69,7 @@ public class JRDateType extends SubmissionSingleValueBase<JRTemporal> {
       raw = parsed
           .map(Date::toInstant)
           .map(i -> OffsetDateTime.ofInstant(i, ZoneId.systemDefault()))
-          .map(odt -> odt.format(DateTimeFormatter.ISO_DATE));
+          .map(odt -> odt.format(DateTimeFormatter.ISO_LOCAL_DATE));
     } else
       for (FormDataModel m : element.getFormDataModel().getChildren()) {
         switch (m.getOrdinalNumber().intValue()) {

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporal.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporal.java
@@ -17,7 +17,7 @@
 package org.opendatakit.aggregate.submission.type.jr;
 
 import static java.time.ZoneId.systemDefault;
-import static java.time.format.DateTimeFormatter.ISO_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
 import static java.util.Objects.requireNonNull;
@@ -56,7 +56,7 @@ public interface JRTemporal<T extends Temporal> {
 
   static JRTemporal date(Date parsed) {
     OffsetDateTime value = OffsetDateTime.ofInstant(requireNonNull(parsed).toInstant(), systemDefault()).truncatedTo(ChronoUnit.DAYS);
-    return new JRDate(Date.from(value.toInstant()), value.toLocalDate(), value.format(ISO_DATE));
+    return new JRDate(Date.from(value.toInstant()), value.toLocalDate(), value.format(ISO_LOCAL_DATE));
   }
 
   static JRTemporal date(Date parsed, String raw) {


### PR DESCRIPTION
Closes #346

This
#### What has been done to verify that this works as intended?
Manually tested with a form uploaded with Aggregate v1.x, and then loaded with this PR (v2.x)

#### Why is this the best possible solution? Were any other approaches considered?
Format dates with ISO_LOCAL_DATE formater to avoid non-parseable values
- ISO_DATE will output `2018-01-01+01:00` if there's time zone info, which we won't be able to parse with LocalDate.parse()

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Any form with a date field will do.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.