### PR TITLE
Issue 336 remove google account credentials

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/permissions/AccessConfigurationSheet.java
+++ b/src/main/java/org/opendatakit/aggregate/client/permissions/AccessConfigurationSheet.java
@@ -64,20 +64,8 @@ import org.opendatakit.common.web.client.UIVisiblePredicate;
 
 public class AccessConfigurationSheet extends Composite {
 
-  private static final String NOT_VALID_EMAIL = "Username is not a valid Email address.\n\n"
-      + "Usernames for Google accounts must be\n" + "Email addresses that Google can\n"
-      + "authenticate (Google login is not supported at this time).";
-
-  private static final ArrayList<String> userType;
-  private static final String ACCOUNT_TYPE_ODK = "ODK";
   private static TemporaryAccessConfigurationSheetUiBinder uiBinder = GWT
       .create(TemporaryAccessConfigurationSheetUiBinder.class);
-
-  static {
-    // TODO Make this a singletonList and inline
-    userType = new ArrayList<String>();
-    userType.add(ACCOUNT_TYPE_ODK);
-  }
 
   private final ListDataProvider<UserSecurityInfo> dataProvider = new ListDataProvider<UserSecurityInfo>();
   private final ListHandler<UserSecurityInfo> columnSortHandler = new ListHandler<UserSecurityInfo>(

--- a/src/main/java/org/opendatakit/aggregate/client/permissions/AccessConfigurationSheet.ui.xml
+++ b/src/main/java/org/opendatakit/aggregate/client/permissions/AccessConfigurationSheet.ui.xml
@@ -12,9 +12,6 @@
       <li>via an <strong>ODK account</strong>, with a username and password that a site
         administrator has configured for them.
       </li>
-      <li>via an <strong>Oauth 2.0 token</strong> (requires an Email account (e.g., user@gmail.com)
-        and an Oauth 2.0 token issued by Google with access to userInfo.email)
-      </li>
     </ul>
     <h4>Capabilities are as follows:</h4>
     <ul>
@@ -62,11 +59,7 @@
     <g:Button styleName="gwt-Button" ui:field="button" text="Save Changes"/>
     <hr/>
     <h3>Add Users</h3>
-    <p>Enter the usernames (for ODK accounts) or e-mail addresses (for Google Gmail accounts) to add
-      to the
-      list of users in the above table. Iteractive logins with Google accounts are no longer
-      supported.
-    </p>
+    <p>Enter the usernames to add to the list of users in the above table (one per line)</p>
     <g:TextArea visibleLines="3" characterWidth="80" ui:field="addedUsers"/>
     <br/>
     <g:Button styleName="gwt-Button" ui:field="addNow" text="Add"/>

--- a/src/main/java/org/opendatakit/common/security/server/SecurityServiceUtil.java
+++ b/src/main/java/org/opendatakit/common/security/server/SecurityServiceUtil.java
@@ -181,7 +181,7 @@ public class SecurityServiceUtil {
 
   public static void setAuthenticationListsForSpecialUser(UserSecurityInfo userInfo, GrantedAuthorityName specialGroup, CallingContext cc) throws DatastoreFailureException {
     RoleHierarchy hierarchy = (RoleHierarchy) cc.getBean("hierarchicalRoleRelationships");
-    Set<GrantedAuthority> badGrants = new TreeSet<GrantedAuthority>();
+    Set<GrantedAuthority> badGrants = new HashSet<>();
     // The assigned groups are the specialGroup that this user defines
     // (i.e., anonymous or daemon) plus all directly-assigned assignable
     // permissions.
@@ -264,7 +264,7 @@ public class SecurityServiceUtil {
   }
 
   private static void setUsersOfGrantedAuthority(Map<UserSecurityInfo, String> pkMap, GrantedAuthority auth, CallingContext cc) throws DatastoreFailureException {
-    Set<GrantedAuthority> badGrants = new TreeSet<GrantedAuthority>();
+    Set<GrantedAuthority> badGrants = new HashSet<>();
     GrantedAuthorityName name = mapName(auth, badGrants);
     if (name != null) {
       // build the set of uriUsers for this granted authority...


### PR DESCRIPTION
Closes #336

First commit: `Fix user adding textbox to prevent Google Accounts`

#### What has been done to verify that this works as intended?
Manually tried (and failed) to create new google account credentials.

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest possible change, which only involves client changes. Changing server side code felt too difficult and risky.

#### Are there any risks to merging this code? If so, what are they?
- Users should expect to be unable to create google account credentials.
- Since no server side code has been changed, existing google account credentials should work (not verified)

Also, during installation, we should suggest users to either migrate accounts to normal ODK type accounts or remove their google account credentials.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

I bet! I'll create issues once the release is ready.