### PR TITLE
Issue 361 normalize temporal data handling code

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/externalservice/GoogleSpreadsheet.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/GoogleSpreadsheet.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Google Inc.
  * Copyright (C) 2010 University of Washington.
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,6 +17,8 @@
  */
 
 package org.opendatakit.aggregate.externalservice;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -51,8 +54,8 @@ import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,10 +96,6 @@ import org.opendatakit.common.web.constants.HtmlConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements ExternalService {
   private static final Logger logger = LoggerFactory.getLogger(GoogleSpreadsheet.class.getName());
 
@@ -198,7 +197,7 @@ public class GoogleSpreadsheet extends GoogleOauth2ExternalService implements Ex
 
       // create spreadsheet
       String spreadsheetName = getSpreadsheetName();
-      String spreadsheetDescription = spreadsheetName + " ODK Aggregate " + WebUtils.iso8601Date(new Date());
+      String spreadsheetDescription = spreadsheetName + " ODK Aggregate " + OffsetDateTime.now().format(ISO_OFFSET_DATE_TIME);
       // will hold doc id
       String spreadKey = null;
       try {

--- a/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
@@ -97,16 +97,8 @@ public class BasicElementFormatter implements ElementFormatter {
     basicStringConversion(b.toString(), row);
   }
 
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-    rfc1123Conversion(date, JRTemporal::date, row);
-  }
-
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
     rfc1123Conversion(date, JRTemporal::dateTime, row);
-  }
-
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    isoLocalTimeConversion(date, row);
   }
 
   public void formatDecimal(WrappedBigDecimal dub, FormElementModel element, String ordinalValue, Row row) {

--- a/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
@@ -17,6 +17,7 @@
 package org.opendatakit.aggregate.format.element;
 
 import static java.lang.String.join;
+import static java.time.format.FormatStyle.MEDIUM;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 
@@ -76,7 +77,7 @@ public class BasicElementFormatter implements ElementFormatter {
   public void formatDateTime(Date value, FormElementModel element, String ordinalValue, Row row) {
     row.addFormattedValue(Optional.ofNullable(value)
         .map(JRTemporal::dateTime)
-        .map(JRTemporal::getRaw)
+        .map(jrt -> jrt.humanFormat(MEDIUM))
         .orElse(null));
   }
 
@@ -90,21 +91,21 @@ public class BasicElementFormatter implements ElementFormatter {
   @Override
   public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
     row.addFormattedValue(Optional.ofNullable(value)
-        .map(JRTemporal::getRaw)
+        .map(JRTemporal::humanFormat)
         .orElse(null));
   }
 
   @Override
   public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
     row.addFormattedValue(Optional.ofNullable(value)
-        .map(JRTemporal::getRaw)
+        .map(JRTemporal::humanFormat)
         .orElse(null));
   }
 
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
     row.addFormattedValue(Optional.ofNullable(value)
-        .map(JRTemporal::getRaw)
+        .map(JRTemporal::humanFormat)
         .orElse(null));
   }
 

--- a/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,9 +17,11 @@
 package org.opendatakit.aggregate.format.element;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
-import static org.opendatakit.common.utils.WebUtils.*;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -32,14 +35,9 @@ import org.opendatakit.aggregate.submission.type.GeoPoint;
 import org.opendatakit.aggregate.submission.type.jr.JRTemporal;
 import org.opendatakit.common.persistence.WrappedBigDecimal;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
 
-/**
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public class BasicElementFormatter implements ElementFormatter {
 
   /**
@@ -190,7 +188,10 @@ public class BasicElementFormatter implements ElementFormatter {
 
   private void rfc1123Conversion(Optional<JRTemporal> value, Row row) {
     basicStringConversion(value
-        .map(v -> rfc1123Date(v.getParsed()))
+        .map(v -> {
+          // TODO This may produce strange results with JRDate and JRTime objects. Also, RFC1123 dates require time
+          return OffsetDateTime.ofInstant(v.getParsed().toInstant(), ZoneId.systemDefault()).format(RFC_1123_DATE_TIME);
+        })
         .orElse(null), row);
   }
 

--- a/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
@@ -111,26 +111,22 @@ public class BasicElementFormatter implements ElementFormatter {
 
   @Override
   public void formatGeoPoint(GeoPoint value, FormElementModel element, String ordinalValue, Row row) {
+    if (value == null) {
+      row.addFormattedValue(null);
+      return;
+    }
+
     if (separateCoordinates) {
-      row.addFormattedValue(Optional.ofNullable(value)
-          .map(GeoPoint::getLatitude)
-          .map(WrappedBigDecimal::toString)
-          .orElse(null));
-      row.addFormattedValue(Optional.ofNullable(value)
-          .map(GeoPoint::getLongitude)
-          .map(WrappedBigDecimal::toString)
-          .orElse(null));
+      row.addFormattedValue(value.getLatitude().toString());
+      row.addFormattedValue(value.getLongitude().toString());
       if (includeAltitude)
-        row.addFormattedValue(Optional.ofNullable(value)
-            .map(GeoPoint::getAltitude)
-            .map(WrappedBigDecimal::toString)
-            .orElse(null));
+        row.addFormattedValue(value.getAltitude().toString());
       if (includeAccuracy)
-        row.addFormattedValue(Optional.ofNullable(value)
-            .map(GeoPoint::getAccuracy)
-            .map(WrappedBigDecimal::toString)
-            .orElse(null));
-    } else if (value.getLongitude() != null && value.getLatitude() != null) {
+        row.addFormattedValue(value.getAccuracy().toString());
+      return;
+    }
+
+    if (value.getLongitude() != null && value.getLatitude() != null) {
       List<WrappedBigDecimal> parts = new ArrayList<>();
       parts.add(value.getLatitude());
       parts.add(value.getLongitude());
@@ -139,8 +135,8 @@ public class BasicElementFormatter implements ElementFormatter {
       if (includeAccuracy)
         parts.add(value.getAccuracy());
       row.addFormattedValue(parts.stream().map(WrappedBigDecimal::toString).collect(joining(", ")));
-    } else
-      row.addFormattedValue(null);
+    }
+
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
@@ -17,12 +17,9 @@
 package org.opendatakit.aggregate.format.element;
 
 import static java.lang.String.join;
-import static java.time.ZoneId.systemDefault;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -44,10 +41,10 @@ public class BasicElementFormatter implements ElementFormatter {
   private boolean includeAltitude;
   private boolean includeAccuracy;
 
-  public BasicElementFormatter(boolean separateGpsCoordinates, boolean includeGpsAltitude, boolean includeGpsAccuracy) {
-    separateCoordinates = separateGpsCoordinates;
-    includeAltitude = includeGpsAltitude;
-    includeAccuracy = includeGpsAccuracy;
+  public BasicElementFormatter(boolean separateCoordinates, boolean includeAltitude, boolean includeAccuracy) {
+    this.separateCoordinates = separateCoordinates;
+    this.includeAltitude = includeAltitude;
+    this.includeAccuracy = includeAccuracy;
   }
 
   @Override
@@ -78,7 +75,8 @@ public class BasicElementFormatter implements ElementFormatter {
   @Override
   public void formatDateTime(Date value, FormElementModel element, String ordinalValue, Row row) {
     row.addFormattedValue(Optional.ofNullable(value)
-        .map(date -> OffsetDateTime.ofInstant(date.toInstant(), systemDefault()).format(RFC_1123_DATE_TIME))
+        .map(JRTemporal::dateTime)
+        .map(JRTemporal::getRaw)
         .orElse(null));
   }
 
@@ -106,7 +104,7 @@ public class BasicElementFormatter implements ElementFormatter {
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
     row.addFormattedValue(Optional.ofNullable(value)
-        .map(dateTime -> OffsetDateTime.ofInstant(dateTime.getParsed().toInstant(), systemDefault()).format(RFC_1123_DATE_TIME))
+        .map(JRTemporal::getRaw)
         .orElse(null));
   }
 

--- a/src/main/java/org/opendatakit/aggregate/format/element/ElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/ElementFormatter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,39 +28,31 @@ import org.opendatakit.common.persistence.WrappedBigDecimal;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.web.CallingContext;
 
-/**
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public interface ElementFormatter {
-  public void formatUid(String uri, String propertyName, Row row);
+  void formatUid(String uri, String propertyName, Row row);
 
-  public void formatBinary(BlobSubmissionType blobSubmission, FormElementModel element, String ordinalValue, Row row, CallingContext cc) throws ODKDatastoreException;
+  void formatBinary(BlobSubmissionType blobSubmission, FormElementModel element, String ordinalValue, Row row, CallingContext cc) throws ODKDatastoreException;
 
-  public void formatBoolean(Boolean bool, FormElementModel element, String ordinalValue, Row row);
+  void formatBoolean(Boolean bool, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatChoices(List<String> choices, FormElementModel element, String ordinalValue, Row row);
+  void formatChoices(List<String> choices, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row);
+  void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row);
+  void formatDecimal(WrappedBigDecimal dub, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row);
+  void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatDecimal(WrappedBigDecimal dub, FormElementModel element, String ordinalValue, Row row);
+  void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row);
+  void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row);
+  void formatGeoPoint(GeoPoint coordinate, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row);
+  void formatLong(Long longInt, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatGeoPoint(GeoPoint coordinate, FormElementModel element, String ordinalValue, Row row);
+  void formatString(String string, FormElementModel element, String ordinalValue, Row row);
 
-  public void formatLong(Long longInt, FormElementModel element, String ordinalValue, Row row);
-
-  public void formatString(String string, FormElementModel element, String ordinalValue, Row row);
-
-  public void formatRepeats(SubmissionRepeat repeat, FormElementModel repeatElement, Row row, CallingContext cc) throws ODKDatastoreException;
+  void formatRepeats(SubmissionRepeat repeat, FormElementModel repeatElement, Row row, CallingContext cc) throws ODKDatastoreException;
 
 }

--- a/src/main/java/org/opendatakit/aggregate/format/element/HtmlLinkElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/HtmlLinkElementFormatter.java
@@ -64,23 +64,23 @@ public class HtmlLinkElementFormatter extends BasicElementFormatter {
   }
 
   @Override
-  public void formatBinary(BlobSubmissionType blobSubmission, FormElementModel element, String ordinalValue, Row row, CallingContext cc) throws ODKDatastoreException {
-    if (blobSubmission == null ||
-        (blobSubmission.getAttachmentCount(cc) == 0) ||
-        (blobSubmission.getContentHash(1, cc) == null)) {
+  public void formatBinary(BlobSubmissionType value, FormElementModel element, String ordinalValue, Row row, CallingContext cc) throws ODKDatastoreException {
+    if (value == null ||
+        (value.getAttachmentCount(cc) == 0) ||
+        (value.getContentHash(1, cc) == null)) {
       row.addFormattedValue(null);
       return;
     }
 
-    SubmissionKey key = blobSubmission.getValue();
+    SubmissionKey key = value.getValue();
     String linkText;
     Map<String, String> properties = new HashMap<String, String>();
     properties.put(ServletConsts.BLOB_KEY, key.toString());
     if (binariesAsDownloadLink) {
       properties.put(ServletConsts.AS_ATTACHMENT, "yes");
       linkText = FormTableConsts.DOWNLOAD_LINK_TEXT;
-      if (blobSubmission.getAttachmentCount(cc) == 1) {
-        linkText = blobSubmission.getUnrootedFilename(1, cc);
+      if (value.getAttachmentCount(cc) == 1) {
+        linkText = value.getUnrootedFilename(1, cc);
         if (linkText == null || linkText.length() == 0) {
           linkText = FormTableConsts.DOWNLOAD_LINK_TEXT;
         }

--- a/src/main/java/org/opendatakit/aggregate/format/element/JsonElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/JsonElementFormatter.java
@@ -215,18 +215,8 @@ public class JsonElementFormatter implements ElementFormatter {
   }
 
   @Override
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToJsonTemporal(date, JRTemporal::date, element, row);
-  }
-
-  @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
     addToJsonTemporal(date, JRTemporal::dateTime, element, row);
-  }
-
-  @Override
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToJsonTemporal(date, JRTemporal::time, element, row);
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/format/element/JsonElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/JsonElementFormatter.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.commons.codec.binary.Base64;
 import org.opendatakit.aggregate.constants.HtmlUtil;
 import org.opendatakit.aggregate.constants.ServletConsts;
@@ -216,7 +215,12 @@ public class JsonElementFormatter implements ElementFormatter {
 
   @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToJsonTemporal(date, JRTemporal::dateTime, element, row);
+    addToJsonValueToRow(
+        Optional.ofNullable(date).map(JRTemporal::dateTime).map(JRTemporal::getRaw).orElse(null),
+        true,
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
@@ -226,17 +230,32 @@ public class JsonElementFormatter implements ElementFormatter {
 
   @Override
   public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToJsonTemporal(value, element, row);
+    addToJsonValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        true,
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
   public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToJsonTemporal(value, element, row);
+    addToJsonValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        true,
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToJsonTemporal(value, element, row);
+    addToJsonValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        true,
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
@@ -292,18 +311,6 @@ public class JsonElementFormatter implements ElementFormatter {
   @Override
   public void formatString(String string, FormElementModel element, String ordinalValue, Row row) {
     addToJsonValueToRow(string, true, element.getElementName(), row);
-  }
-
-  private void addToJsonTemporal(Date value, Function<Date, JRTemporal> mapper, FormElementModel element, Row row) {
-    addToJsonTemporal(Optional.ofNullable(value).map(mapper).map(JRTemporal::getRaw), element, row);
-  }
-
-  private void addToJsonTemporal(JRTemporal value, FormElementModel element, Row row) {
-    addToJsonTemporal(Optional.ofNullable(value).map(JRTemporal::getRaw), element, row);
-  }
-
-  private void addToJsonTemporal(Optional<String> value, FormElementModel element, Row row) {
-    addToJsonValueToRow(value.orElse(null), true, element.getElementName(), row);
   }
 
   private void addToJsonValueToRow(Object value, boolean quoted, String propertyName, Row row) {

--- a/src/main/java/org/opendatakit/aggregate/format/element/KmlElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/KmlElementFormatter.java
@@ -110,18 +110,8 @@ public class KmlElementFormatter implements ElementFormatter {
   }
 
   @Override
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(date, JRTemporal::date, element, ordinalValue, row);
-  }
-
-  @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
     generateTemporalElement(date, JRTemporal::dateTime, element, ordinalValue, row);
-  }
-
-  @Override
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(date, JRTemporal::time, element, ordinalValue, row);
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/format/element/KmlElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/KmlElementFormatter.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import org.opendatakit.aggregate.constants.HtmlUtil;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.constants.format.FormTableConsts;
@@ -111,7 +110,11 @@ public class KmlElementFormatter implements ElementFormatter {
 
   @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(date, JRTemporal::dateTime, element, ordinalValue, row);
+    generateDataElement(
+        Optional.ofNullable(date).map(JRTemporal::dateTime).map(JRTemporal::getRaw).orElse(null),
+        element + FormatConsts.HEADER_CONCAT + ordinalValue,
+        row
+    );
   }
 
   @Override
@@ -121,17 +124,29 @@ public class KmlElementFormatter implements ElementFormatter {
 
   @Override
   public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(value, element, ordinalValue, row);
+    generateDataElement(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        element + FormatConsts.HEADER_CONCAT + ordinalValue,
+        row
+    );
   }
 
   @Override
   public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(value, element, ordinalValue, row);
+    generateDataElement(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        element + FormatConsts.HEADER_CONCAT + ordinalValue,
+        row
+    );
   }
 
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(value, element, ordinalValue, row);
+    generateDataElement(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        element + FormatConsts.HEADER_CONCAT + ordinalValue,
+        row
+    );
   }
 
   @Override
@@ -160,22 +175,6 @@ public class KmlElementFormatter implements ElementFormatter {
   @Override
   public void formatString(String string, FormElementModel element, String ordinalValue, Row row) {
     generateDataElement(string, element.getGroupQualifiedElementName() + ordinalValue, row);
-  }
-
-  private void generateTemporalElement(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(Optional.ofNullable(value), element, ordinalValue, row);
-  }
-
-  private void generateTemporalElement(Date value, Function<Date, JRTemporal> mapper, FormElementModel element, String ordinalValue, Row row) {
-    generateTemporalElement(Optional.ofNullable(value).map(mapper), element, ordinalValue, row);
-  }
-
-  private void generateTemporalElement(Optional<JRTemporal> value, FormElementModel element, String ordinalValue, Row row) {
-    generateDataElement(
-        value.map(JRTemporal::getRaw).orElse(null),
-        element + FormatConsts.HEADER_CONCAT + ordinalValue,
-        row
-    );
   }
 
   private void generateDataElement(Object value, String name, Row row) {

--- a/src/main/java/org/opendatakit/aggregate/format/element/LinkElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/LinkElementFormatter.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import org.opendatakit.aggregate.constants.HtmlUtil;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
@@ -69,22 +68,22 @@ public class LinkElementFormatter extends BasicElementFormatter {
 
   @Override
   public void formatDateTime(Date value, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(value, JRTemporal::dateTime, row);
+    row.addFormattedValue(Optional.ofNullable(value).map(JRTemporal::dateTime).map(JRTemporal::getRaw).orElse(null));
   }
 
   @Override
   public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(value, row);
+    row.addFormattedValue(Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null));
   }
 
   @Override
   public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(value, row);
+    row.addFormattedValue(Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null));
   }
 
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(value, row);
+    row.addFormattedValue(Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null));
   }
 
   @Override
@@ -104,15 +103,4 @@ public class LinkElementFormatter extends BasicElementFormatter {
         ServletConsts.FORM_ID, row);
   }
 
-  private void temporalConversion(Date value, Function<Date, JRTemporal> mapper, Row row) {
-    temporalConversion(Optional.ofNullable(value).map(mapper), row);
-  }
-
-  private void temporalConversion(JRTemporal value, Row row) {
-    temporalConversion(Optional.ofNullable(value), row);
-  }
-
-  private void temporalConversion(Optional<JRTemporal> value, Row row) {
-    row.addFormattedValue(Optional.ofNullable((Object) value.map(JRTemporal::getRaw).orElse(null)).map(Object::toString).orElse(null));
-  }
 }

--- a/src/main/java/org/opendatakit/aggregate/format/element/LinkElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/LinkElementFormatter.java
@@ -68,16 +68,6 @@ public class LinkElementFormatter extends BasicElementFormatter {
   }
 
   @Override
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(date, JRTemporal::time, row);
-  }
-
-  @Override
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(date, JRTemporal::date, row);
-  }
-
-  @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
     temporalConversion(date, JRTemporal::dateTime, row);
   }

--- a/src/main/java/org/opendatakit/aggregate/format/element/LinkElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/LinkElementFormatter.java
@@ -54,22 +54,22 @@ public class LinkElementFormatter extends BasicElementFormatter {
   }
 
   @Override
-  public void formatBinary(BlobSubmissionType blobSubmission, FormElementModel element, String ordinalValue, Row row, CallingContext cc)
+  public void formatBinary(BlobSubmissionType value, FormElementModel element, String ordinalValue, Row row, CallingContext cc)
       throws ODKDatastoreException {
-    if (blobSubmission == null ||
-        (blobSubmission.getAttachmentCount(cc) == 0) ||
-        (blobSubmission.getContentHash(1, cc) == null)) {
+    if (value == null ||
+        (value.getAttachmentCount(cc) == 0) ||
+        (value.getContentHash(1, cc) == null)) {
       row.addFormattedValue(null);
       return;
     }
 
-    addFormattedLink(blobSubmission.getValue(), BinaryDataServlet.ADDR,
+    addFormattedLink(value.getValue(), BinaryDataServlet.ADDR,
         ServletConsts.BLOB_KEY, row);
   }
 
   @Override
-  public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    temporalConversion(date, JRTemporal::dateTime, row);
+  public void formatDateTime(Date value, FormElementModel element, String ordinalValue, Row row) {
+    temporalConversion(value, JRTemporal::dateTime, row);
   }
 
   @Override
@@ -113,6 +113,6 @@ public class LinkElementFormatter extends BasicElementFormatter {
   }
 
   private void temporalConversion(Optional<JRTemporal> value, Row row) {
-    basicStringConversion(value.map(JRTemporal::getRaw).orElse(null), row);
+    row.addFormattedValue(Optional.ofNullable((Object) value.map(JRTemporal::getRaw).orElse(null)).map(Object::toString).orElse(null));
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/format/element/UiElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/UiElementFormatter.java
@@ -17,6 +17,7 @@ package org.opendatakit.aggregate.format.element;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.opendatakit.aggregate.constants.HtmlUtil;
 import org.opendatakit.aggregate.constants.ServletConsts;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
@@ -47,7 +48,7 @@ public class UiElementFormatter extends BasicElementFormatter {
   }
 
   @Override
-  public void formatGeoPoint(GeoPoint coordinate, FormElementModel element, String ordinalValue, Row row) {
+  public void formatGeoPoint(GeoPoint value, FormElementModel element, String ordinalValue, Row row) {
     GeopointHeaderIncludes gpsFormatter = null;
 
     if (gpsFormatters != null) {
@@ -55,39 +56,39 @@ public class UiElementFormatter extends BasicElementFormatter {
     }
 
     if (gpsFormatter == null) {
-      formatBigDecimalToString(coordinate.getLatitude(), row);
-      formatBigDecimalToString(coordinate.getLongitude(), row);
-      formatBigDecimalToString(coordinate.getAltitude(), row);
-      formatBigDecimalToString(coordinate.getAccuracy(), row);
+      row.addFormattedValue(Optional.ofNullable((Object) value.getLatitude()).map(Object::toString).orElse(null));
+      row.addFormattedValue(Optional.ofNullable((Object) value.getLongitude()).map(Object::toString).orElse(null));
+      row.addFormattedValue(Optional.ofNullable((Object) value.getAltitude()).map(Object::toString).orElse(null));
+      row.addFormattedValue(Optional.ofNullable((Object) value.getAccuracy()).map(Object::toString).orElse(null));
     } else {
       if (gpsFormatter.includeLatitude()) {
-        formatBigDecimalToString(coordinate.getLatitude(), row);
+        row.addFormattedValue(Optional.ofNullable((Object) value.getLatitude()).map(Object::toString).orElse(null));
       }
 
       if (gpsFormatter.includeLongitude()) {
-        formatBigDecimalToString(coordinate.getLongitude(), row);
+        row.addFormattedValue(Optional.ofNullable((Object) value.getLongitude()).map(Object::toString).orElse(null));
       }
 
       if (gpsFormatter.includeAltitude()) {
-        formatBigDecimalToString(coordinate.getAltitude(), row);
+        row.addFormattedValue(Optional.ofNullable((Object) value.getAltitude()).map(Object::toString).orElse(null));
       }
 
       if (gpsFormatter.includeAccuracy()) {
-        formatBigDecimalToString(coordinate.getAccuracy(), row);
+        row.addFormattedValue(Optional.ofNullable((Object) value.getAccuracy()).map(Object::toString).orElse(null));
       }
     }
   }
 
   @Override
-  public void formatBinary(BlobSubmissionType blobSubmission, FormElementModel element, String ordinalValue, Row row, CallingContext cc) throws ODKDatastoreException {
-    if (blobSubmission == null ||
-        (blobSubmission.getAttachmentCount(cc) == 0) ||
-        (blobSubmission.getContentHash(1, cc) == null)) {
+  public void formatBinary(BlobSubmissionType value, FormElementModel element, String ordinalValue, Row row, CallingContext cc) throws ODKDatastoreException {
+    if (value == null ||
+        (value.getAttachmentCount(cc) == 0) ||
+        (value.getContentHash(1, cc) == null)) {
       row.addFormattedValue(null);
       return;
     }
 
-    SubmissionKey key = blobSubmission.getValue();
+    SubmissionKey key = value.getValue();
     Map<String, String> properties = new HashMap<String, String>();
     properties.put(ServletConsts.BLOB_KEY, key.toString());
     String url = HtmlUtil.createLinkWithProperties(baseWebServerUrl + BasicConsts.FORWARDSLASH + BinaryDataServlet.ADDR, properties);

--- a/src/main/java/org/opendatakit/aggregate/format/element/XmlAttributeFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/XmlAttributeFormatter.java
@@ -19,7 +19,6 @@ package org.opendatakit.aggregate.format.element;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.opendatakit.aggregate.constants.ParserConsts;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
@@ -111,7 +110,11 @@ public class XmlAttributeFormatter implements ElementFormatter {
 
   @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(date, JRTemporal::dateTime, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(date).map(JRTemporal::dateTime).map(JRTemporal::getRaw).orElse(null),
+        asAttributeName(element),
+        row
+    );
   }
 
   @Override
@@ -121,17 +124,29 @@ public class XmlAttributeFormatter implements ElementFormatter {
 
   @Override
   public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(value, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        asAttributeName(element),
+        row
+    );
   }
 
   @Override
   public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(value, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        asAttributeName(element),
+        row
+    );
   }
 
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(value, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        asAttributeName(element),
+        row
+    );
   }
 
   @Override
@@ -169,18 +184,6 @@ public class XmlAttributeFormatter implements ElementFormatter {
   @Override
   public void formatString(String string, FormElementModel element, String ordinalValue, Row row) {
     addToXmlValueToRow(string, asAttributeName(element), row);
-  }
-
-  private void addToXmlTemporal(Date value, Function<Date, JRTemporal> mapper, FormElementModel element, Row row) {
-    addToXmlTemporal(Optional.ofNullable(value).map(mapper), element, row);
-  }
-
-  private void addToXmlTemporal(JRTemporal value, FormElementModel element, Row row) {
-    addToXmlTemporal(Optional.ofNullable(value), element, row);
-  }
-
-  private void addToXmlTemporal(Optional<JRTemporal> value, FormElementModel element, Row row) {
-    addToXmlValueToRow(value.map(JRTemporal::getRaw).orElse(null), asAttributeName(element), row);
   }
 
   private void addToXmlValueToRow(Object value, String propertyName, Row row) {

--- a/src/main/java/org/opendatakit/aggregate/format/element/XmlAttributeFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/XmlAttributeFormatter.java
@@ -110,18 +110,8 @@ public class XmlAttributeFormatter implements ElementFormatter {
   }
 
   @Override
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(date, JRTemporal::date, element, row);
-  }
-
-  @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
     addToXmlTemporal(date, JRTemporal::dateTime, element, row);
-  }
-
-  @Override
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(date, JRTemporal::time, element, row);
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/format/element/XmlElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/XmlElementFormatter.java
@@ -102,18 +102,8 @@ public class XmlElementFormatter implements ElementFormatter {
   }
 
   @Override
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(date, JRTemporal::date, element, row);
-  }
-
-  @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
     addToXmlTemporal(date, JRTemporal::dateTime, element, row);
-  }
-
-  @Override
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(date, JRTemporal::time, element, row);
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/format/element/XmlElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/XmlElementFormatter.java
@@ -19,7 +19,6 @@ package org.opendatakit.aggregate.format.element;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.opendatakit.aggregate.constants.HtmlUtil;
 import org.opendatakit.aggregate.datamodel.FormElementModel;
@@ -103,7 +102,11 @@ public class XmlElementFormatter implements ElementFormatter {
 
   @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(date, JRTemporal::dateTime, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(date).map(JRTemporal::dateTime).map(JRTemporal::getRaw).orElse(null),
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
@@ -113,17 +116,29 @@ public class XmlElementFormatter implements ElementFormatter {
 
   @Override
   public void formatJRDate(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(value, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
   public void formatJRTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(value, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
   public void formatJRDateTime(JRTemporal value, FormElementModel element, String ordinalValue, Row row) {
-    addToXmlTemporal(value, element, row);
+    addToXmlValueToRow(
+        Optional.ofNullable(value).map(JRTemporal::getRaw).orElse(null),
+        element.getElementName(),
+        row
+    );
   }
 
   @Override
@@ -155,19 +170,6 @@ public class XmlElementFormatter implements ElementFormatter {
 
   @Override
   public void formatRepeats(SubmissionRepeat repeat, FormElementModel repeatElement, Row row, CallingContext cc) {
-  }
-
-  private void addToXmlTemporal(Date value, Function<Date, JRTemporal> mapper, FormElementModel element, Row row) {
-    Optional<JRTemporal> jrTemporal = Optional.ofNullable(value).map(mapper);
-    addToXmlMapper(jrTemporal, element, row);
-  }
-
-  private void addToXmlTemporal(JRTemporal value, FormElementModel element, Row row) {
-    addToXmlMapper(Optional.ofNullable(value), element, row);
-  }
-
-  private void addToXmlMapper(Optional<JRTemporal> value, FormElementModel element, Row row) {
-    addToXmlValueToRow(value.map(JRTemporal::getRaw).orElse(null), element.getElementName(), row);
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/format/element/XmlMediaAttachmentFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/XmlMediaAttachmentFormatter.java
@@ -90,15 +90,7 @@ public class XmlMediaAttachmentFormatter implements ElementFormatter {
   }
 
   @Override
-  public void formatDate(Date date, FormElementModel element, String ordinalValue, Row row) {
-  }
-
-  @Override
   public void formatDateTime(Date date, FormElementModel element, String ordinalValue, Row row) {
-  }
-
-  @Override
-  public void formatTime(Date date, FormElementModel element, String ordinalValue, Row row) {
   }
 
   @Override

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -23,7 +23,6 @@ import static org.opendatakit.aggregate.constants.ParserConsts.FORM_ID_ATTRIBUTE
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH_SUBSTITUTION;
 import static org.opendatakit.aggregate.constants.ParserConsts.NAMESPACE_ODK;
-import static org.opendatakit.aggregate.submission.type.jr.JRTemporal.fixOffset;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -413,7 +412,6 @@ public class BaseFormParserForJavaRosa {
         return new Date();
       ++endIdx;
       String timestamp = xml.substring(idx + ODK_TIMESTAMP_COMMENT.length(), endIdx);
-      // TODO Remove coupling with JRTemporal.fixOffset(String)
       Date d = Date.from(OffsetDateTime.parse(fixOffset(timestamp)).toInstant());
       if (d != null) {
         return d;
@@ -1052,4 +1050,10 @@ public class BaseFormParserForJavaRosa {
     // database schema
     XFORMS_MISSING_VERSION, XFORMS_EARLIER_VERSION
   }
+
+  private static String fixOffset(String raw) {
+    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
+    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
+  }
+
 }

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Google Inc.
  * Copyright (C) 2010 University of Washington.
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,13 +18,16 @@
 
 package org.opendatakit.aggregate.parser;
 
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORM_ID_ATTRIBUTE_NAME;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH_SUBSTITUTION;
 import static org.opendatakit.aggregate.constants.ParserConsts.NAMESPACE_ODK;
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporal.fixOffset;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,20 +55,12 @@ import org.kxml2.kdom.Node;
 import org.opendatakit.aggregate.exception.ODKIncompleteSubmissionData;
 import org.opendatakit.aggregate.exception.ODKIncompleteSubmissionData.Reason;
 import org.opendatakit.aggregate.form.XFormParameters;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-/**
- * Parses an XML definition of an XForm based on java rosa types
- *
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- * @author chrislrobert@gmail.com
- */
 public class BaseFormParserForJavaRosa {
 
   private static final String LEADING_QUESTION_XML_PATTERN = "^[^<]*<\\s*\\?\\s*xml.*";
@@ -417,7 +413,8 @@ public class BaseFormParserForJavaRosa {
         return new Date();
       ++endIdx;
       String timestamp = xml.substring(idx + ODK_TIMESTAMP_COMMENT.length(), endIdx);
-      Date d = WebUtils.parseDate(timestamp);
+      // TODO Remove coupling with JRTemporal.fixOffset(String)
+      Date d = Date.from(OffsetDateTime.parse(fixOffset(timestamp)).toInstant());
       if (d != null) {
         return d;
       } else {
@@ -432,7 +429,7 @@ public class BaseFormParserForJavaRosa {
     int idx = xmlInsertLocation(xmlWithoutTimestampComment);
 
     return xmlWithoutTimestampComment.substring(0, idx) + ODK_TIMESTAMP_COMMENT
-        + WebUtils.iso8601Date(new Date()) + " on " + serverUrl + " -->"
+        + OffsetDateTime.now().format(ISO_OFFSET_DATE_TIME) + " on " + serverUrl + " -->"
         + xmlWithoutTimestampComment.substring(idx);
   }
 

--- a/src/main/java/org/opendatakit/aggregate/parser/SubmissionParser.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/SubmissionParser.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Google Inc.
  * Copyright (C) 2010 University of Washington.
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -46,6 +47,7 @@ import org.opendatakit.aggregate.submission.SubmissionField;
 import org.opendatakit.aggregate.submission.SubmissionSet;
 import org.opendatakit.aggregate.submission.type.BlobSubmissionType;
 import org.opendatakit.aggregate.submission.type.RepeatSubmissionType;
+import org.opendatakit.aggregate.submission.type.jr.JRTemporal;
 import org.opendatakit.common.datamodel.DeleteHelper;
 import org.opendatakit.common.datamodel.ODKEnumeratedElementException;
 import org.opendatakit.common.persistence.CommonFieldsBase;
@@ -67,12 +69,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-/**
- * Parsers submission xml and saves to datastore
- *
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public class SubmissionParser {
 
   private static final String OPEN_ROSA_NAMESPACE_PRELIM = "http://openrosa.org/xforms/metadata";
@@ -251,14 +247,14 @@ public class SubmissionParser {
     Date submissionDate = new Date();
     String submissionDateString = root.getAttribute(ParserConsts.SUBMISSION_DATE_ATTRIBUTE_NAME);
     if (submissionDateString != null && submissionDateString.length() != 0) {
-      submissionDate = WebUtils.parseDate(submissionDateString);
+      submissionDate = JRTemporal.dateTime(submissionDateString).getParsed();
     }
 
     Date markedAsCompleteDate = new Date();
     String markedAsCompleteDateString = root
         .getAttribute(ParserConsts.MARKED_AS_COMPLETE_DATE_ATTRIBUTE_NAME);
     if (markedAsCompleteDateString != null && markedAsCompleteDateString.length() != 0) {
-      markedAsCompleteDate = WebUtils.parseDate(markedAsCompleteDateString);
+      markedAsCompleteDate = JRTemporal.dateTime(markedAsCompleteDateString).getParsed();
     }
 
     SubmissionLockTemplate modificationLock = new SubmissionLockTemplate(formId, instanceId, cc);

--- a/src/main/java/org/opendatakit/aggregate/query/submission/QueryByUIFilterGroup.java
+++ b/src/main/java/org/opendatakit/aggregate/query/submission/QueryByUIFilterGroup.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,6 +39,7 @@ import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.aggregate.server.UITrans;
 import org.opendatakit.aggregate.submission.Submission;
 import org.opendatakit.aggregate.submission.SubmissionKey;
+import org.opendatakit.aggregate.submission.type.jr.JRTemporal;
 import org.opendatakit.common.datamodel.ODKEnumeratedElementException;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.Query;
@@ -169,9 +171,11 @@ public class QueryByUIFilterGroup extends QueryBase {
       case BOOLEAN:
         return WebUtils.parseBoolean(value);
       case JRDATETIME:
+        return JRTemporal.dateTime(value).getParsed();
       case JRDATE:
+        return JRTemporal.date(value).getParsed();
       case JRTIME:
-        return WebUtils.parseDate(value);
+        return JRTemporal.time(value).getParsed();
       case INTEGER:
         return Long.valueOf(value);
       case DECIMAL:

--- a/src/main/java/org/opendatakit/aggregate/server/FormAdminServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/FormAdminServiceImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,7 +28,7 @@ import static org.opendatakit.aggregate.form.MiscTasks.TaskType.DELETE_FORM;
 import static org.opendatakit.aggregate.form.MiscTasks.TaskType.PURGE_OLDER_SUBMISSIONS;
 import static org.opendatakit.aggregate.query.submission.QueryByUIFilterGroup.CompletionFlag.ONLY_INCOMPLETE_SUBMISSIONS;
 import static org.opendatakit.aggregate.task.PurgeOlderSubmissions.PURGE_DATE;
-import static org.opendatakit.common.utils.WebUtils.purgeDateString;
+import static org.opendatakit.aggregate.task.PurgeOlderSubmissions.formatPurgeDate;
 
 import com.google.gwt.user.server.rpc.XsrfProtectedServiceServlet;
 import java.util.ArrayList;
@@ -149,7 +150,7 @@ public class FormAdminServiceImpl extends XsrfProtectedServiceServlet implements
     // set up the purge request here...
     Map<String, String> parameters = new HashMap<>();
 
-    parameters.put(PURGE_DATE, purgeDateString(earliest));
+    parameters.put(PURGE_DATE, formatPurgeDate(earliest));
     IForm form;
     try {
       form = retrieveFormByFormId(fsc.getFormId(), cc);
@@ -427,7 +428,7 @@ public class FormAdminServiceImpl extends XsrfProtectedServiceServlet implements
     // set up the purge request here...
     Map<String, String> parameters = new HashMap<>();
 
-    parameters.put(PURGE_DATE, purgeDateString(value));
+    parameters.put(PURGE_DATE, PurgeOlderSubmissions.formatPurgeDate(value));
 
     MiscTasks m;
     try {

--- a/src/main/java/org/opendatakit/aggregate/servlet/BinaryDataServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/BinaryDataServlet.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Google Inc.
  * Copyright (C) 2010 University of Washington.
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +18,13 @@
 
 package org.opendatakit.aggregate.servlet;
 
+import static java.time.ZoneId.systemDefault;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
@@ -39,18 +45,11 @@ import org.opendatakit.aggregate.submission.type.BlobSubmissionType;
 import org.opendatakit.aggregate.util.ImageUtil;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.HtmlConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Servlet to display the binary data from a submission
- *
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public class BinaryDataServlet extends ServletUtilBase {
 
   /**
@@ -266,10 +265,8 @@ public class BinaryDataServlet extends ServletUtilBase {
 
       if (previewSize) {
         // cache for 1 hour...
-        resp.setHeader("Expires:",
-            WebUtils.rfc1123Date(new Date(System.currentTimeMillis() + 3600000L)));
-        resp.setHeader("Last-Modified:",
-            WebUtils.rfc1123Date(lastUpdateDate));
+        resp.setHeader("Expires:", OffsetDateTime.now().plus(Duration.ofHours(1)).format(RFC_1123_DATE_TIME));
+        resp.setHeader("Last-Modified:", OffsetDateTime.ofInstant(lastUpdateDate.toInstant(), systemDefault()).format(RFC_1123_DATE_TIME));
         resp.setContentType(HtmlConsts.RESP_TYPE_IMAGE_JPEG);
         if (contentType.equals(HtmlConsts.RESP_TYPE_IMAGE_JPEG)) {
           // resize
@@ -281,8 +278,7 @@ public class BinaryDataServlet extends ServletUtilBase {
         }
         resp.setContentLength(imageBlob.length);
       } else {
-        resp.setHeader("Last-Modified:",
-            WebUtils.rfc1123Date(lastUpdateDate));
+        resp.setHeader("Last-Modified:", OffsetDateTime.ofInstant(lastUpdateDate.toInstant(), systemDefault()).format(RFC_1123_DATE_TIME));
         resp.setContentType(contentType);
         if (contentLength != null) {
           resp.setContentLength(contentLength.intValue());

--- a/src/main/java/org/opendatakit/aggregate/servlet/FragmentedCsvServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/FragmentedCsvServlet.java
@@ -18,7 +18,6 @@
 
 package org.opendatakit.aggregate.servlet;
 
-import static org.opendatakit.aggregate.submission.type.jr.JRTemporal.fixOffset;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -45,7 +44,6 @@ import org.opendatakit.aggregate.submission.SubmissionKey;
 import org.opendatakit.aggregate.submission.SubmissionKeyPart;
 import org.opendatakit.aggregate.submission.SubmissionSet;
 import org.opendatakit.aggregate.submission.type.RepeatSubmissionType;
-import org.opendatakit.aggregate.submission.type.jr.JRTemporal;
 import org.opendatakit.common.persistence.QueryResumePoint;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
 import org.opendatakit.common.web.CallingContext;
@@ -265,7 +263,6 @@ public class FragmentedCsvServlet extends ServletUtilBase {
 
         if (!submissions.isEmpty()) {
           QueryResumePoint resumeCursor = query.getResumeCursor();
-          // TODO Remove coupling with JRTemporal.fixOffset(String)
           Date resumeDate = Date.from(OffsetDateTime.parse(fixOffset(resumeCursor.getValue())).toInstant());
           websafeCursorString = Long.toString(resumeDate.getTime())
               + " and " + resumeCursor.getUriLastReturnedValue();
@@ -296,4 +293,10 @@ public class FragmentedCsvServlet extends ServletUtilBase {
       errorRetreivingData(resp);
     }
   }
+
+  private static String fixOffset(String raw) {
+    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
+    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
+  }
+
 }

--- a/src/main/java/org/opendatakit/aggregate/servlet/FragmentedCsvServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/FragmentedCsvServlet.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009 Google Inc.
  * Copyright (C) 2010 University of Washington.
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,8 +18,11 @@
 
 package org.opendatakit.aggregate.servlet;
 
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporal.fixOffset;
+
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -41,19 +45,13 @@ import org.opendatakit.aggregate.submission.SubmissionKey;
 import org.opendatakit.aggregate.submission.SubmissionKeyPart;
 import org.opendatakit.aggregate.submission.SubmissionSet;
 import org.opendatakit.aggregate.submission.type.RepeatSubmissionType;
+import org.opendatakit.aggregate.submission.type.jr.JRTemporal;
 import org.opendatakit.common.persistence.QueryResumePoint;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.opendatakit.common.web.constants.HtmlConsts;
 
-/**
- * Servlet to generate a CSV file for download, in parts!
- *
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public class FragmentedCsvServlet extends ServletUtilBase {
 
   /**
@@ -267,7 +265,8 @@ public class FragmentedCsvServlet extends ServletUtilBase {
 
         if (!submissions.isEmpty()) {
           QueryResumePoint resumeCursor = query.getResumeCursor();
-          Date resumeDate = WebUtils.parseDate(resumeCursor.getValue());
+          // TODO Remove coupling with JRTemporal.fixOffset(String)
+          Date resumeDate = Date.from(OffsetDateTime.parse(fixOffset(resumeCursor.getValue())).toInstant());
           websafeCursorString = Long.toString(resumeDate.getTime())
               + " and " + resumeCursor.getUriLastReturnedValue();
         } else {

--- a/src/main/java/org/opendatakit/aggregate/servlet/GetUsersAndPermissionsServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/GetUsersAndPermissionsServlet.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,10 +16,12 @@
  */
 package org.opendatakit.aggregate.servlet;
 
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+
 import java.io.IOException;
 import java.io.StringWriter;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.TreeSet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -34,7 +37,6 @@ import org.opendatakit.common.security.client.UserSecurityInfo.UserType;
 import org.opendatakit.common.security.common.EmailParser;
 import org.opendatakit.common.security.common.GrantedAuthorityName;
 import org.opendatakit.common.security.server.SecurityServiceUtil;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.HtmlConsts;
 import org.slf4j.Logger;
@@ -43,8 +45,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Servlet for downloading a .csv file containing a list of users and their privileges.
  * This must contain all the users and their privileges on the system.
- *
- * @author mitchellsundt@gmail.com
  */
 public class GetUsersAndPermissionsServlet extends ServletUtilBase {
 
@@ -121,8 +121,7 @@ public class GetUsersAndPermissionsServlet extends ServletUtilBase {
     resp.setHeader("Pragma:", "no-cache");
     resp.setHeader("Expires:", "0");
 
-    resp.setHeader("Last-Modified:",
-        WebUtils.rfc1123Date(new Date()));
+    resp.setHeader("Last-Modified:", OffsetDateTime.now().format(RFC_1123_DATE_TIME));
     resp.setContentType(HtmlConsts.RESP_TYPE_CSV);
     resp.addHeader(HtmlConsts.CONTENT_DISPOSITION, "attachment; filename=\"UsersAndCapabilities.csv\"");
     resp.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRDate.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRDate.java
@@ -16,8 +16,15 @@
 
 package org.opendatakit.aggregate.submission.type.jr;
 
+import static java.time.format.DateTimeFormatter.ofLocalizedDate;
+import static java.time.format.FormatStyle.LONG;
+import static java.util.Locale.ENGLISH;
+import static org.opendatakit.common.utils.LocaleUtils.withLocale;
+
 import java.time.LocalDate;
+import java.time.format.FormatStyle;
 import java.util.Date;
+import java.util.Locale;
 
 public class JRDate implements JRTemporal<LocalDate> {
   private final Date parsed;
@@ -43,5 +50,10 @@ public class JRDate implements JRTemporal<LocalDate> {
   @Override
   public LocalDate getValue() {
     return value;
+  }
+
+  @Override
+  public String humanFormat(FormatStyle style) {
+    return withLocale(ENGLISH, () -> value.format(ofLocalizedDate(style)));
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRDateTime.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRDateTime.java
@@ -16,7 +16,13 @@
 
 package org.opendatakit.aggregate.submission.type.jr;
 
+import static java.time.format.DateTimeFormatter.ofLocalizedDateTime;
+import static java.time.format.FormatStyle.LONG;
+import static java.util.Locale.ENGLISH;
+import static org.opendatakit.common.utils.LocaleUtils.withLocale;
+
 import java.time.OffsetDateTime;
+import java.time.format.FormatStyle;
 import java.util.Date;
 
 public class JRDateTime implements JRTemporal<OffsetDateTime> {
@@ -43,5 +49,12 @@ public class JRDateTime implements JRTemporal<OffsetDateTime> {
   @Override
   public OffsetDateTime getValue() {
     return value;
+  }
+
+  @Override
+  public String humanFormat(FormatStyle style) {
+    return withLocale(ENGLISH, () -> value
+        .toZonedDateTime()
+        .format(ofLocalizedDateTime(style)));
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporal.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporal.java
@@ -22,6 +22,7 @@ import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
 import static java.time.format.FormatStyle.LONG;
 import static java.util.Objects.requireNonNull;
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporalUtils.fixOffset;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -78,11 +79,6 @@ public interface JRTemporal<T extends Temporal> {
   static JRTemporal dateTime(Date parsed, String raw) {
     OffsetDateTime value = OffsetDateTime.parse(fixOffset(raw));
     return new JRDateTime(parsed, value, raw);
-  }
-
-  static String fixOffset(String raw) {
-    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
-    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
   }
 
   Date getParsed();

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporal.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporal.java
@@ -20,11 +20,13 @@ import static java.time.ZoneId.systemDefault;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
+import static java.time.format.FormatStyle.LONG;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.format.FormatStyle;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Date;
@@ -88,4 +90,10 @@ public interface JRTemporal<T extends Temporal> {
   String getRaw();
 
   T getValue();
+
+  default String humanFormat() {
+    return humanFormat(LONG);
+  }
+
+  String humanFormat(FormatStyle style);
 }

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.submission.type.jr;
+
+final class JRTemporalUtils {
+  private JRTemporalUtils() {
+    // Prevent instantiation of this class
+  }
+
+  static String fixOffset(String raw) {
+    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
+    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
+  }
+}

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTime.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTime.java
@@ -16,7 +16,11 @@
 
 package org.opendatakit.aggregate.submission.type.jr;
 
+import static java.time.format.DateTimeFormatter.ofLocalizedTime;
+
+import java.time.LocalDate;
 import java.time.OffsetTime;
+import java.time.format.FormatStyle;
 import java.util.Date;
 
 public class JRTime implements JRTemporal<OffsetTime> {
@@ -43,5 +47,13 @@ public class JRTime implements JRTemporal<OffsetTime> {
   @Override
   public OffsetTime getValue() {
     return value;
+  }
+
+  @Override
+  public String humanFormat(FormatStyle style) {
+    return value
+        .atDate(LocalDate.now())
+        .toZonedDateTime()
+        .format(ofLocalizedTime(style));
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/task/PurgeOlderSubmissions.java
+++ b/src/main/java/org/opendatakit/aggregate/task/PurgeOlderSubmissions.java
@@ -16,6 +16,19 @@
  */
 package org.opendatakit.aggregate.task;
 
+import static java.time.ZoneId.systemDefault;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Date;
+import java.util.Optional;
 import org.opendatakit.aggregate.constants.BeanDefs;
 import org.opendatakit.aggregate.form.IForm;
 import org.opendatakit.aggregate.submission.SubmissionKey;
@@ -24,6 +37,30 @@ import org.opendatakit.common.web.CallingContext;
 public class PurgeOlderSubmissions {
 
   public static final String PURGE_DATE = "purgeBefore";
+  private static final DateTimeFormatter PURGE_DATE_TIME_FORMAT = new DateTimeFormatterBuilder()
+      .parseCaseInsensitive()
+      .append(ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+      .appendValue(HOUR_OF_DAY, 2)
+      .appendLiteral(':')
+      .appendValue(MINUTE_OF_HOUR, 2)
+      .appendLiteral(':')
+      .appendValue(SECOND_OF_MINUTE, 2)
+      .toFormatter();
+  private static final ZoneOffset SYSTEM_OFFSET = OffsetDateTime.now().getOffset();
+
+
+  public static String formatPurgeDate(Date value) {
+    return Optional.ofNullable(value)
+        .map(date -> LocalDateTime.ofInstant(date.toInstant(), systemDefault()).format(PURGE_DATE_TIME_FORMAT))
+        .orElse(null);
+  }
+
+  static Date parsePurgeDate(String value) {
+    return Optional.ofNullable(value)
+        .map(date -> Date.from(LocalDateTime.parse(date, PURGE_DATE_TIME_FORMAT).toInstant(SYSTEM_OFFSET)))
+        .orElse(null);
+  }
 
   public final void createPurgeOlderSubmissionsTask(IForm form, SubmissionKey miscTasksKey, long attemptCount, CallingContext cc) {
     Watchdog wd = (Watchdog) cc.getBean(BeanDefs.WATCHDOG);

--- a/src/main/java/org/opendatakit/aggregate/task/PurgeOlderSubmissionsWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/PurgeOlderSubmissionsWorkerImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,6 +15,8 @@
  * the License.
  */
 package org.opendatakit.aggregate.task;
+
+import static org.opendatakit.aggregate.task.PurgeOlderSubmissions.*;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -40,7 +43,6 @@ import org.opendatakit.common.persistence.exception.ODKEntityPersistException;
 import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
 import org.opendatakit.common.persistence.exception.ODKTaskLockException;
 import org.opendatakit.common.security.User;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.slf4j.Logger;
@@ -49,9 +51,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Common worker implementation for the purging of all of a form's submissions
  * older than a given date.
- *
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
  */
 public class PurgeOlderSubmissionsWorkerImpl {
   private static final int MAX_QUERY_LIMIT = 100;
@@ -164,8 +163,8 @@ public class PurgeOlderSubmissionsWorkerImpl {
     Logger logger = LoggerFactory.getLogger(PurgeOlderSubmissionsWorkerImpl.class);
 
     Map<String, String> rp = t.getRequestParameters();
-    String purgeBeforeDateString = rp.get(PurgeOlderSubmissions.PURGE_DATE);
-    Date purgeBeforeDate = WebUtils.parsePurgeDateString(purgeBeforeDateString);
+    String purgeBeforeDateString = rp.get(PURGE_DATE);
+    Date purgeBeforeDate = parsePurgeDate(purgeBeforeDateString);
 
     logger.info("Submissions Purge: " + miscTasksKey.toString() + " form "
         + form.getFormId() + " doPurgeOlderSubmissions date: " + purgeBeforeDateString);

--- a/src/main/java/org/opendatakit/aggregate/task/WatchdogWorkerImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/task/WatchdogWorkerImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,6 +16,10 @@
  */
 package org.opendatakit.aggregate.task;
 
+import static java.time.ZoneId.systemDefault;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -41,17 +46,10 @@ import org.opendatakit.aggregate.util.BackendActionsTable;
 import org.opendatakit.common.persistence.PersistConsts;
 import org.opendatakit.common.persistence.QueryResumePoint;
 import org.opendatakit.common.persistence.exception.ODKDatastoreException;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Common worker implementation for restarting stalled tasks.
- *
- * @author wbrunette@gmail.com
- * @author mitchellsundt@gmail.com
- */
 public class WatchdogWorkerImpl {
 
   private Logger logger = LoggerFactory.getLogger(WatchdogWorkerImpl.class);
@@ -69,7 +67,7 @@ public class WatchdogWorkerImpl {
     // limitDate is the datastore's settle time into the past.
     Date limitDate = new Date(System.currentTimeMillis() - PersistConsts.MAX_SETTLE_MILLISECONDS);
     QueryResumePoint qrp = new QueryResumePoint(
-        TopLevelDynamicBase.FIELD_NAME_MARKED_AS_COMPLETE_DATE, WebUtils.iso8601Date(limitDate),
+        TopLevelDynamicBase.FIELD_NAME_MARKED_AS_COMPLETE_DATE, OffsetDateTime.ofInstant(limitDate.toInstant(), systemDefault()).format(ISO_OFFSET_DATE_TIME),
         null, false);
 
     FilterGroup filterGroup = new FilterGroup(UIConsts.FILTER_NONE, form.getFormId(), null);

--- a/src/main/java/org/opendatakit/common/persistence/engine/EngineUtils.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/EngineUtils.java
@@ -19,7 +19,6 @@ package org.opendatakit.common.persistence.engine;
 
 import static java.time.ZoneId.systemDefault;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-import static org.opendatakit.aggregate.submission.type.jr.JRTemporal.fixOffset;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -193,7 +192,6 @@ public class EngineUtils {
         if (v == null) {
           value = null;
         } else {
-          // TODO Remove coupling with JRTemporal.fixOffset(String)
           value = Date.from(OffsetDateTime.parse(fixOffset(v)).toInstant());
         }
         break;
@@ -202,6 +200,11 @@ public class EngineUtils {
         throw new IllegalStateException("datatype not handled");
     }
     return value;
+  }
+
+  private static String fixOffset(String raw) {
+    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
+    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
   }
 
 }

--- a/src/main/java/org/opendatakit/common/persistence/engine/EngineUtils.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/EngineUtils.java
@@ -1,19 +1,28 @@
 /*
-  Copyright (C) 2011 University of Washington
-  <p>
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-  in compliance with the License. You may obtain a copy of the License at
-  <p>
-  http://www.apache.org/licenses/LICENSE-2.0
-  <p>
-  Unless required by applicable law or agreed to in writing, software distributed under the License
-  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-  or implied. See the License for the specific language governing permissions and limitations under
-  the License.
+ * Copyright (C) 2011 University of Washington.
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+
 package org.opendatakit.common.persistence.engine;
 
+import static java.time.ZoneId.systemDefault;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporal.fixOffset;
+
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.Date;
 import org.opendatakit.common.persistence.CommonFieldsBase;
 import org.opendatakit.common.persistence.DataField;
@@ -22,73 +31,7 @@ import org.opendatakit.common.utils.WebUtils;
 
 public class EngineUtils {
 
-  public static final Object getDominantSortAttributeValue(CommonFieldsBase odkEntity, DataField dominantAttr) {
-    switch (dominantAttr.getDataType()) {
-      case BINARY:
-        throw new IllegalStateException("unexpected sort on binary field");
-      case LONG_STRING:
-        throw new IllegalStateException("unexpected sort on long text field");
-      case URI:
-      case STRING:
-        return odkEntity.getStringField(dominantAttr);
-      case INTEGER:
-        return odkEntity.getLongField(dominantAttr);
-      case DECIMAL:
-        return odkEntity.getNumericField(dominantAttr);
-      case BOOLEAN:
-        return odkEntity.getBooleanField(dominantAttr);
-      case DATETIME:
-        return odkEntity.getDateField(dominantAttr);
-      default:
-        throw new IllegalStateException("unexpected data type");
-    }
-  }
-
-  public static final boolean hasMatchingDominantSortAttribute(CommonFieldsBase odkLastEntity, CommonFieldsBase odkEntity, DataField dominantAttr) {
-    boolean matchingDominantAttr = false;
-    switch (dominantAttr.getDataType()) {
-      case BINARY:
-        throw new IllegalStateException("unexpected sort on binary field");
-      case LONG_STRING:
-        throw new IllegalStateException("unexpected sort on long text field");
-      case URI:
-      case STRING: {
-        String a1 = odkLastEntity.getStringField(dominantAttr);
-        String a2 = odkEntity.getStringField(dominantAttr);
-        matchingDominantAttr = (a1 == null) ? (a2 == null) : ((a2 != null) && a1.compareTo(a2) == 0);
-      }
-      break;
-      case INTEGER: {
-        Long a1 = odkLastEntity.getLongField(dominantAttr);
-        Long a2 = odkEntity.getLongField(dominantAttr);
-        matchingDominantAttr = (a1 == null) ? (a2 == null) : ((a2 != null) && a1.compareTo(a2) == 0);
-      }
-      break;
-      case DECIMAL: {
-        WrappedBigDecimal a1 = odkLastEntity.getNumericField(dominantAttr);
-        WrappedBigDecimal a2 = odkEntity.getNumericField(dominantAttr);
-        matchingDominantAttr = (a1 == null) ? (a2 == null) : ((a2 != null) && a1.compareTo(a2) == 0);
-      }
-      break;
-      case BOOLEAN: {
-        Boolean a1 = odkLastEntity.getBooleanField(dominantAttr);
-        Boolean a2 = odkEntity.getBooleanField(dominantAttr);
-        matchingDominantAttr = (a1 == null) ? (a2 == null) : ((a2 != null) && a1.compareTo(a2) == 0);
-      }
-      break;
-      case DATETIME: {
-        Date a1 = odkLastEntity.getDateField(dominantAttr);
-        Date a2 = odkEntity.getDateField(dominantAttr);
-        matchingDominantAttr = (a1 == null) ? (a2 == null) : ((a2 != null) && a1.compareTo(a2) == 0);
-      }
-      break;
-      default:
-        throw new IllegalStateException("unexpected data type");
-    }
-    return matchingDominantAttr;
-  }
-
-  public static final String getDominantSortAttributeValueAsString(CommonFieldsBase cb, DataField dominantAttr) {
+  public static String getDominantSortAttributeValueAsString(CommonFieldsBase cb, DataField dominantAttr) {
     String value;
     switch (dominantAttr.getDataType()) {
       case BINARY:
@@ -132,7 +75,7 @@ public class EngineUtils {
         if (d == null) {
           value = null;
         } else {
-          value = WebUtils.iso8601Date(d);
+          value = OffsetDateTime.ofInstant(d.toInstant(), systemDefault()).format(ISO_OFFSET_DATE_TIME);
         }
         break;
       }
@@ -142,7 +85,7 @@ public class EngineUtils {
     return value;
   }
 
-  public static final String getAttributeValueAsString(Object o, DataField dominantAttr) {
+  public static String getAttributeValueAsString(Object o, DataField dominantAttr) {
     String value;
     switch (dominantAttr.getDataType()) {
       case BINARY:
@@ -196,7 +139,7 @@ public class EngineUtils {
         if (d == null) {
           value = null;
         } else {
-          value = WebUtils.iso8601Date(d);
+          value = OffsetDateTime.ofInstant(d.toInstant(), systemDefault()).format(ISO_OFFSET_DATE_TIME);
         }
         break;
       }
@@ -206,7 +149,7 @@ public class EngineUtils {
     return value;
   }
 
-  public static final Object getDominantSortAttributeValueFromString(String v, DataField dominantAttr) {
+  public static Object getDominantSortAttributeValueFromString(String v, DataField dominantAttr) {
     Object value;
     switch (dominantAttr.getDataType()) {
       case BINARY:
@@ -250,7 +193,8 @@ public class EngineUtils {
         if (v == null) {
           value = null;
         } else {
-          value = WebUtils.parseDate(v);
+          // TODO Remove coupling with JRTemporal.fixOffset(String)
+          value = Date.from(OffsetDateTime.parse(fixOffset(v)).toInstant());
         }
         break;
       }

--- a/src/main/java/org/opendatakit/common/security/spring/Oauth2AuthenticationToken.java
+++ b/src/main/java/org/opendatakit/common/security/spring/Oauth2AuthenticationToken.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,18 +16,19 @@
  */
 package org.opendatakit.common.security.spring;
 
+import static java.time.ZoneId.systemDefault;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import org.opendatakit.common.utils.WebUtils;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 
 /**
  * Authentication that is returned by Oauth 2.0 processing.
  * Structure liberally copied from Spring OpenId and Oauth2 authentication token classes.
- *
- * @author mitchellsundt@gmail.com
  */
 public class Oauth2AuthenticationToken extends AbstractAuthenticationToken {
 
@@ -103,6 +105,6 @@ public class Oauth2AuthenticationToken extends AbstractAuthenticationToken {
   @Override
   public String toString() {
     return "[" + super.toString() + ", email : " + email +
-        ", expiration : " + WebUtils.iso8601Date(expiration) + "]";
+        ", expiration : " + OffsetDateTime.ofInstant(expiration.toInstant(), systemDefault()).format(ISO_OFFSET_DATE_TIME) + "]";
   }
 }

--- a/src/main/java/org/opendatakit/common/security/spring/RegisteredUsersTable.java
+++ b/src/main/java/org/opendatakit/common/security/spring/RegisteredUsersTable.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 University of Washington
+ * Copyright (C) 2018 Nafundi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,9 +16,11 @@
  */
 package org.opendatakit.common.security.spring;
 
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
 import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.common.persistence.CommonFieldsBase;
@@ -38,7 +41,6 @@ import org.opendatakit.common.security.client.CredentialsInfo;
 import org.opendatakit.common.security.client.RealmSecurityInfo;
 import org.opendatakit.common.security.client.UserSecurityInfo;
 import org.opendatakit.common.security.common.EmailParser.Email;
-import org.opendatakit.common.utils.WebUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,8 +70,6 @@ import org.springframework.security.authentication.encoding.MessageDigestPasswor
  * IS_REMOVED = true. This allows audit tracking back to the username. Once
  * marked as IS_REMOVED, that row is never reinstated. The superuser must create
  * a new row for the user.
- *
- * @author mitchellsundt@gmail.com
  */
 public final class RegisteredUsersTable extends CommonFieldsBase {
 
@@ -81,8 +81,8 @@ public final class RegisteredUsersTable extends CommonFieldsBase {
   // Unique key (disregarding removed) or null
   private static final DataField LOCAL_USERNAME = new DataField("LOCAL_USERNAME", DataField.DataType.STRING, true, 80L).setIndexable(IndexType.ORDERED);
   // Unique key (disregarding removed) or null
-  // NOTE: the column name in the database is not changed. This was 
-  // used for OpenID authentication originally, but now is used for 
+  // NOTE: the column name in the database is not changed. This was
+  // used for OpenID authentication originally, but now is used for
   // OAuth2 authentication.
   private static final DataField OAUTH2_EMAIL = new DataField("OPENID_EMAIL", DataField.DataType.STRING, true, 80L).setIndexable(IndexType.ORDERED);
   private static final DataField FULL_NAME = new DataField("FULL_NAME", DataField.DataType.STRING, true);
@@ -138,10 +138,10 @@ public final class RegisteredUsersTable extends CommonFieldsBase {
   public static final String generateUniqueUri(String username, String email) {
     String uri;
     if (username == null) {
-      uri = UID_PREFIX + email.substring(SecurityUtils.MAILTO_COLON.length()) + "|"
-          + WebUtils.iso8601Date(new Date());
+      // TODO Improve this SecurityUtils.MAILTO_COLON.length() business here
+      uri = UID_PREFIX + email.substring(SecurityUtils.MAILTO_COLON.length()) + "|" + OffsetDateTime.now().format(ISO_OFFSET_DATE_TIME);
     } else {
-      uri = UID_PREFIX + username + "|" + WebUtils.iso8601Date(new Date());
+      uri = UID_PREFIX + username + "|" + OffsetDateTime.now().format(ISO_OFFSET_DATE_TIME);
     }
     return uri;
   }

--- a/src/main/java/org/opendatakit/common/utils/LocaleUtils.java
+++ b/src/main/java/org/opendatakit/common/utils/LocaleUtils.java
@@ -31,4 +31,11 @@ public final class LocaleUtils {
     Locale.setDefault(backup);
     return t;
   }
+
+  public synchronized static void withLocale(Locale locale, Runnable supplier) {
+    Locale backup = Locale.getDefault();
+    Locale.setDefault(locale);
+    supplier.run();
+    Locale.setDefault(backup);
+  }
 }

--- a/src/main/java/org/opendatakit/common/utils/LocaleUtils.java
+++ b/src/main/java/org/opendatakit/common/utils/LocaleUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.common.utils;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+
+public final class LocaleUtils {
+  private LocaleUtils() {
+    // Prevent construction of this class
+  }
+
+  public synchronized static <T> T withLocale(Locale locale, Supplier<T> supplier) {
+    Locale backup = Locale.getDefault();
+    Locale.setDefault(locale);
+    T t = supplier.get();
+    Locale.setDefault(backup);
+    return t;
+  }
+}

--- a/src/main/java/org/opendatakit/common/utils/WebUtils.java
+++ b/src/main/java/org/opendatakit/common/utils/WebUtils.java
@@ -1,16 +1,20 @@
 /*
-  Copyright (C) 2011 University of Washington
-  <p>
-  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-  in compliance with the License. You may obtain a copy of the License at
-  <p>
-  http://www.apache.org/licenses/LICENSE-2.0
-  <p>
-  Unless required by applicable law or agreed to in writing, software distributed under the License
-  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-  or implied. See the License for the specific language governing permissions and limitations under
-  the License.
+ * Copyright (C) 2011 University of Washington
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
+
 package org.opendatakit.common.utils;
 
 import java.io.BufferedReader;
@@ -18,26 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.javarosa.core.model.utils.DateUtils;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.opendatakit.common.web.constants.HtmlConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Useful methods for parsing boolean and date values and formatting dates.
- *
- * @author mitchellsundt@gmail.com
- */
 public class WebUtils {
 
   static final String IS_FORWARD_CURSOR_VALUE_TAG = "isForwardCursor";
@@ -46,25 +37,11 @@ public class WebUtils {
   static final String ATTRIBUTE_NAME_TAG = "attributeName";
   static final String CURSOR_TAG = "cursor";
   static final Logger logger = LoggerFactory.getLogger(WebUtils.class);
-  private static final String PATTERN_RFC1123 = "EEE, dd MMM yyyy HH:mm:ss zzz";
-  private static final String PATTERN_RFC1036 = "EEEE, dd-MMM-yy HH:mm:ss zzz";
-  private static final String PATTERN_ASCTIME = "EEE MMM d HH:mm:ss yyyy";
-  private static final String PATTERN_DATE_TOSTRING = "EEE MMM dd HH:mm:ss zzz yyyy";
-  private static final String PATTERN_ISO8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-  private static final String PATTERN_ISO8601_WITHOUT_ZONE = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-  private static final String PATTERN_ISO8601_DATE = "yyyy-MM-ddZ";
-  private static final String PATTERN_ISO8601_TIME = "HH:mm:ss.SSSZ";
-  private static final String PATTERN_YYYY_MM_DD_DATE_ONLY_NO_TIME_DASH = "yyyy-MM-dd";
-  private static final String PATTERN_NO_DATE_TIME_ONLY = "HH:mm:ss.SSS";
-  private static final String PATTERN_GOOGLE_DOCS = "MM/dd/yyyy HH:mm:ss.SSS";
-  private static final String PATTERN_GOOGLE_DOCS_DATE_ONLY = "MM/dd/yyyy";
-
-  private static final String PURGE_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
   private WebUtils() {
   }
 
-  public static final Boolean parseBoolean(String value) {
+  public static Boolean parseBoolean(String value) {
     Boolean b = null;
     if (value != null && value.length() != 0) {
       b = Boolean.FALSE;
@@ -81,191 +58,6 @@ public class WebUtils {
       }
     }
     return b;
-  }
-
-  private static final Date parseDateSubset(String value, String[] parsePatterns, Locale l, TimeZone tz) {
-    // borrowed from apache.commons.lang.DateUtils...
-    Date d = null;
-    SimpleDateFormat parser = null;
-    ParsePosition pos = new ParsePosition(0);
-    for (int i = 0; i < parsePatterns.length; i++) {
-      if (i == 0) {
-        if (l == null) {
-          parser = new SimpleDateFormat(parsePatterns[0]);
-        } else {
-          parser = new SimpleDateFormat(parsePatterns[0], l);
-        }
-      } else {
-        parser.applyPattern(parsePatterns[i]);
-      }
-      parser.setTimeZone(tz); // enforce UTC for formats without timezones
-      pos.setIndex(0);
-      d = parser.parse(value, pos);
-      if (d != null && pos.getIndex() == value.length()) {
-        return d;
-      }
-    }
-    return d;
-  }
-
-  public static final Date parseDate(String value) {
-    if (value == null || value.length() == 0)
-      return null;
-
-    String[] iso8601Pattern = new String[]{PATTERN_ISO8601};
-
-    String[] localizedParsePatterns = new String[]{
-        // try the common HTTP date formats that have time zones
-        PATTERN_RFC1123, PATTERN_RFC1036, PATTERN_DATE_TOSTRING};
-
-    String[] localizedNoTzParsePatterns = new String[]{
-        // ones without timezones... (will assume UTC)
-        PATTERN_ASCTIME};
-
-    String[] tzParsePatterns = new String[]{PATTERN_ISO8601, PATTERN_ISO8601_DATE,
-        PATTERN_ISO8601_TIME};
-
-    String[] noTzParsePatterns = new String[]{
-        // ones without timezones... (will assume UTC)
-        PATTERN_ISO8601_WITHOUT_ZONE, PATTERN_NO_DATE_TIME_ONLY,
-        PATTERN_YYYY_MM_DD_DATE_ONLY_NO_TIME_DASH, PATTERN_GOOGLE_DOCS};
-
-    Date d = null;
-    // iso8601 parsing is sometimes off-by-one when JR does it...
-    d = parseDateSubset(value, iso8601Pattern, null, TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    // try to parse with the JavaRosa parsers
-    d = DateUtils.parseDateTime(value);
-    if (d != null)
-      return d;
-    d = DateUtils.parseDate(value);
-    if (d != null)
-      return d;
-    d = DateUtils.parseTime(value);
-    if (d != null)
-      return d;
-    // try localized and english text parsers (for Web headers and interactive
-    // filter spec.)
-    d = parseDateSubset(value, localizedParsePatterns, Locale.ENGLISH, TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    d = parseDateSubset(value, localizedParsePatterns, null, TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    d = parseDateSubset(value, localizedNoTzParsePatterns, Locale.ENGLISH,
-        TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    d = parseDateSubset(value, localizedNoTzParsePatterns, null, TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    // try other common patterns that might not quite match JavaRosa parsers
-    d = parseDateSubset(value, tzParsePatterns, null, TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    d = parseDateSubset(value, noTzParsePatterns, null, TimeZone.getTimeZone("GMT"));
-    if (d != null)
-      return d;
-    // try the locale- and timezone- specific parsers
-    {
-      DateFormat formatter = DateFormat.getDateTimeInstance();
-      ParsePosition pos = new ParsePosition(0);
-      d = formatter.parse(value, pos);
-      if (d != null && pos.getIndex() == value.length()) {
-        return d;
-      }
-    }
-    {
-      DateFormat formatter = DateFormat.getDateInstance();
-      ParsePosition pos = new ParsePosition(0);
-      d = formatter.parse(value, pos);
-      if (d != null && pos.getIndex() == value.length()) {
-        return d;
-      }
-    }
-    {
-      DateFormat formatter = DateFormat.getTimeInstance();
-      ParsePosition pos = new ParsePosition(0);
-      d = formatter.parse(value, pos);
-      if (d != null && pos.getIndex() == value.length()) {
-        return d;
-      }
-    }
-    throw new IllegalArgumentException("Unable to parse the date: " + value);
-  }
-
-  public static final String asSubmissionDateTimeString(Date d) {
-    if (d == null)
-      return null;
-    return DateUtils.formatDateTime(d, DateUtils.FORMAT_ISO8601);
-  }
-
-  public static final String asSubmissionDateOnlyString(Date d) {
-    if (d == null)
-      return null;
-    return DateUtils.formatDate(d, DateUtils.FORMAT_ISO8601);
-  }
-
-  public static final String asSubmissionTimeOnlyString(Date d) {
-    if (d == null)
-      return null;
-    return DateUtils.formatTime(d, DateUtils.FORMAT_ISO8601);
-  }
-
-  public static final String googleDocsDateTime(Date d) {
-    if (d == null)
-      return null;
-    SimpleDateFormat asGoogleDoc = new SimpleDateFormat(PATTERN_GOOGLE_DOCS);
-    asGoogleDoc.setTimeZone(TimeZone.getTimeZone("GMT"));
-    return asGoogleDoc.format(d);
-  }
-
-  public static final String googleDocsDateOnly(Date d) {
-    if (d == null)
-      return null;
-    SimpleDateFormat asGoogleDocDateOnly = new SimpleDateFormat(PATTERN_GOOGLE_DOCS_DATE_ONLY);
-    asGoogleDocDateOnly.setTimeZone(TimeZone.getTimeZone("GMT"));
-    return asGoogleDocDateOnly.format(d);
-  }
-
-  public static final String iso8601Date(Date d) {
-    if (d == null)
-      return null;
-    // SDF is not thread-safe
-    SimpleDateFormat asGMTiso8601 = new SimpleDateFormat(PATTERN_ISO8601); // with
-    // time
-    // zone
-    asGMTiso8601.setTimeZone(TimeZone.getTimeZone("GMT"));
-    return asGMTiso8601.format(d);
-  }
-
-  public static final String rfc1123Date(Date d) {
-    if (d == null)
-      return null;
-    // SDF is not thread-safe
-    SimpleDateFormat asGMTrfc1123 = new SimpleDateFormat(PATTERN_RFC1123); // with
-    // time
-    // zone
-    asGMTrfc1123.setTimeZone(TimeZone.getTimeZone("GMT"));
-    return asGMTrfc1123.format(d);
-  }
-
-  public static final String purgeDateString(Date d) {
-    if (d == null)
-      return null;
-    // SDF is not thread-safe
-    SimpleDateFormat purgeDateFormat = new SimpleDateFormat(PURGE_DATE_FORMAT);
-    return purgeDateFormat.format(d);
-  }
-
-  public static final Date parsePurgeDateString(String str) throws ParseException {
-    if (str == null) {
-      return null;
-    }
-    // SDF is not thread-safe
-    SimpleDateFormat purgeDateFormat = new SimpleDateFormat(PURGE_DATE_FORMAT);
-    return purgeDateFormat.parse(str);
   }
 
   public static String readResponse(HttpResponse resp) throws IOException {

--- a/src/test/java/org/opendatakit/aggregate/format/element/BasicElementFormatterTest.java
+++ b/src/test/java/org/opendatakit/aggregate/format/element/BasicElementFormatterTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.format.element;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import org.junit.Test;
+import org.opendatakit.aggregate.format.Row;
+import org.opendatakit.aggregate.submission.SubmissionKey;
+import org.opendatakit.aggregate.submission.type.GeoPoint;
+import org.opendatakit.aggregate.submission.type.jr.JRTemporal;
+import org.opendatakit.common.persistence.WrappedBigDecimal;
+
+public class BasicElementFormatterTest {
+
+  @Test
+  public void formats_UIDs() {
+    assertThat(formatUid(null), is(nullValue()));
+    assertThat(formatUid(""), is(""));
+    assertThat(formatUid("uuid:8030500e-12c6-40f4-badd-c9e32361f928"), is("uuid:8030500e-12c6-40f4-badd-c9e32361f928"));
+  }
+
+  @Test
+  public void formats_booleans() {
+    assertThat(format((Boolean) null), is(nullValue()));
+    assertThat(format(true), is("true"));
+    assertThat(format(false), is("false"));
+  }
+
+  @Test
+  public void formats_choices() {
+    assertThat(formatChoices((String[]) null), is(""));
+    assertThat(formatChoices(""), is(""));
+    assertThat(formatChoices("choice1"), is("choice1"));
+    assertThat(formatChoices("choice1", "choice2"), is("choice1 choice2"));
+  }
+
+  @Test
+  public void formats_dateTimes_from_metadata_and_generated_data() {
+    OffsetDateTime now = OffsetDateTime.parse("2018-01-01T10:20:30.123Z");
+    assertThat(format((Date) null), is(nullValue()));
+    withOffset("Europe/Madrid", () ->
+        assertThat(format(Date.from(now.toInstant())), is("Jan 1, 2018 11:20:30 AM"))
+    );
+  }
+
+  private static void withOffset(String zoneId, Runnable block) {
+    TimeZone backup = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+    block.run();
+    TimeZone.setDefault(backup);
+  }
+
+  @Test
+  public void formats_decimals() {
+    assertThat(format((WrappedBigDecimal) null), is(nullValue()));
+    assertThat(format(WrappedBigDecimal.fromDouble(1.234)), is("1.234"));
+  }
+
+  @Test
+  public void formats_dates_from_user_input() {
+    assertThat(formatJRDate(null), is(nullValue()));
+    assertThat(formatJRDate(JRTemporal.date("2018-01-01")), is("January 1, 2018"));
+  }
+
+  @Test
+  public void formats_times_from_user_input() {
+    assertThat(formatJRTime(null), is(nullValue()));
+    // Some JVMs can add the AM/PM designation in between
+    assertThat(formatJRTime(JRTemporal.time("10:20:30.123Z")), allOf(startsWith("10:20:30"), endsWith("Z")));
+    assertThat(formatJRTime(JRTemporal.time("10:20:30.123+01:00")), allOf(startsWith("10:20:30"), endsWith("+01:00")));
+  }
+
+  @Test
+  public void formats_dateTimes_from_user_input() {
+    assertThat(formatJRDateTime(null), is(nullValue()));
+    // Some JVMs can add the AM/PM designation in between
+    assertThat(formatJRDateTime(JRTemporal.dateTime("2018-01-01T10:20:30.123Z")), allOf(startsWith("January 1, 2018 10:20:30"), endsWith("Z")));
+    assertThat(formatJRDateTime(JRTemporal.dateTime("2018-01-01T10:20:30.123+01:00")), allOf(startsWith("January 1, 2018 10:20:30"), endsWith("+01:00")));
+  }
+
+  @Test
+  public void formatsgeopoints() {
+    assertThat(format(null, false, false), is(nullValue()));
+    assertThat(format(geopoint(1, 2, 3, 4), false, false), is("1.0, 2.0"));
+    assertThat(format(geopoint(1, 2, 3, 4), true, false), is("1.0, 2.0, 3.0"));
+    assertThat(format(geopoint(1, 2, 3, 4), false, true), is("1.0, 2.0, 4.0")); // Oopsie, this doesn't make much sense...
+    assertThat(format(geopoint(1, 2, 3, 4), true, true), is("1.0, 2.0, 3.0, 4.0"));
+    assertThat(formatSeparated(null, false, false), contains(nullValue()));
+    assertThat(formatSeparated(geopoint(1, 2, 3, 4), false, false), contains("1.0", "2.0"));
+    assertThat(formatSeparated(geopoint(1, 2, 3, 4), true, false), contains("1.0", "2.0", "3.0"));
+    assertThat(formatSeparated(geopoint(1, 2, 3, 4), false, true), contains("1.0", "2.0", "4.0")); // Oopsie, this doesn't make much sense...
+    assertThat(formatSeparated(geopoint(1, 2, 3, 4), true, true), contains("1.0", "2.0", "3.0", "4.0"));
+  }
+
+  @Test
+  public void formats_longs() {
+    assertThat(format((Long) null), is(nullValue()));
+    assertThat(format(1L), is("1"));
+  }
+
+  @Test
+  public void formats_strings() {
+    assertThat(format((String) null), is(nullValue()));
+    assertThat(format("some string"), is("some string"));
+  }
+
+  private GeoPoint geopoint(Number lat, Number lon, Number alt, Number acc) {
+    return new GeoPoint(
+        WrappedBigDecimal.fromDouble(lat.doubleValue()),
+        WrappedBigDecimal.fromDouble(lon.doubleValue()),
+        WrappedBigDecimal.fromDouble(alt.doubleValue()),
+        WrappedBigDecimal.fromDouble(acc.doubleValue())
+    );
+  }
+
+  private static String formatUid(String uid) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatUid(uid, null, row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String format(Boolean value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatBoolean(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String formatChoices(String... choices) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatChoices(choices != null ? Arrays.asList(choices) : null, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String format(Date value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatDateTime(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String format(WrappedBigDecimal value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatDecimal(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String formatJRDate(JRTemporal value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatJRDate(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String formatJRTime(JRTemporal value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatJRTime(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String formatJRDateTime(JRTemporal value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatJRDateTime(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String format(GeoPoint value, boolean includeAltitude, boolean includeAccuracy) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, includeAltitude, includeAccuracy);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatGeoPoint(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static List<String> formatSeparated(GeoPoint value, boolean includeAltitude, boolean includeAccuracy) {
+    BasicElementFormatter formatter = new BasicElementFormatter(true, includeAltitude, includeAccuracy);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatGeoPoint(value, null, "0", row);
+    return row.getFormattedValues();
+  }
+
+  private static String format(Long value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatLong(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+
+  private static String format(String value) {
+    BasicElementFormatter formatter = new BasicElementFormatter(false, false, false);
+    Row row = new Row(new SubmissionKey("submission key"));
+    formatter.formatString(value, null, "0", row);
+    return row.getFormattedValues().get(0);
+  }
+}

--- a/src/test/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalFormattingTest.java
+++ b/src/test/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalFormattingTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.submission.type.jr;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.common.utils.LocaleUtils.withLocale;
+
+import java.util.Locale;
+import org.junit.Test;
+
+public class JRTemporalFormattingTest {
+  @Test
+  public void formats_values_for_humans() {
+    // Some JVMs can add the AM/PM designation in between
+    assertThat(JRTemporal.dateTime("2018-01-01T10:20:30.123Z").humanFormat(), allOf(startsWith("January 1, 2018 10:20:30"), endsWith("Z")));
+    assertThat(JRTemporal.date("2018-01-01").humanFormat(), is("January 1, 2018"));
+    assertThat(JRTemporal.time("10:20:30.123Z").humanFormat(), allOf(startsWith("10:20:30"), endsWith("Z")));
+  }
+
+  @Test
+  public void enforces_the_English_locale_when_formatting_values_for_humans() {
+    withLocale(Locale.forLanguageTag("ES"), () -> {
+      // Some JVMs can add the AM/PM designation in between
+      assertThat(JRTemporal.dateTime("2018-01-01T10:20:30.123Z").humanFormat(), allOf(startsWith("January 1, 2018 10:20:30"), endsWith("Z")));
+      assertThat(JRTemporal.date("2018-01-01").humanFormat(), is("January 1, 2018"));
+      assertThat(JRTemporal.time("10:20:30.123Z").humanFormat(), allOf(startsWith("10:20:30"), endsWith("Z")));
+    });
+  }
+
+
+}

--- a/src/test/java/org/opendatakit/common/persistence/QueryResultTest.java
+++ b/src/test/java/org/opendatakit/common/persistence/QueryResultTest.java
@@ -42,7 +42,7 @@ public class QueryResultTest {
   private static final int SET_SIZE = 3;
   private static final String[] STRINGS = new String[]{"A", "B", "C"};
   private static final double[] DOUBLES = new double[]{0.9, 1.9, 2.9};
-  private static final String[] DATES = new String[]{"2009-01-30", "2009-02-30", "2009-03-30"};
+  private static final String[] DATES = new String[]{"2009-01-30", "2009-02-28", "2009-03-30"};
   private static final Boolean[] BOOLEANS = new Boolean[]{true, false, null};
   private static TestRow[] TEST_ROWS = new TestRow[STRINGS.length * SET_SIZE * DOUBLES.length * DATES.length * BOOLEANS.length];
 

--- a/src/test/java/org/opendatakit/common/persistence/TestRow.java
+++ b/src/test/java/org/opendatakit/common/persistence/TestRow.java
@@ -15,27 +15,24 @@
  */
 package org.opendatakit.common.persistence;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.Date;
-import org.opendatakit.common.persistence.exception.ODKEntityPersistException;
-import org.opendatakit.common.persistence.exception.ODKOverQuotaException;
-import org.opendatakit.common.security.User;
-import org.opendatakit.common.utils.WebUtils;
-import org.opendatakit.common.web.CallingContext;
 
 class TestRow {
-    public final String stringField;
-    public final Integer integerField;
-    public final WrappedBigDecimal doubleField;
-    public final Date dateField;
-    public final Boolean booleanField;
+  public final String stringField;
+  public final Integer integerField;
+  public final WrappedBigDecimal doubleField;
+  public final Date dateField;
+  public final Boolean booleanField;
 
-    TestRow(String someString, Integer someInteger, Double someDouble, String someDate, Boolean someBoolean) {
-        stringField = someString;
-        integerField = someInteger;
-        doubleField = (someDouble == null) ? null : WrappedBigDecimal.fromDouble(someDouble);
-        dateField = WebUtils.parseDate(someDate);
-        booleanField = someBoolean;
-    }
+  TestRow(String someString, Integer someInteger, Double someDouble, String someDate, Boolean someBoolean) {
+    stringField = someString;
+    integerField = someInteger;
+    doubleField = (someDouble == null) ? null : WrappedBigDecimal.fromDouble(someDouble);
+    dateField = Date.from(LocalDate.parse(someDate).atStartOfDay().toInstant(OffsetDateTime.now().getOffset()));
+    booleanField = someBoolean;
+  }
 
 
 }


### PR DESCRIPTION
Closes #361, and #340 

#### What has been done to verify that this works as intended?
- Manually run Aggregate
- There are a few new tests

#### Why is this the best possible solution? Were any other approaches considered?
This change consolidates the changes we started to adapt Aggregate to use ISO8601

#### Are there any risks to merging this code? If so, what are they?

Changes in this PR:
- All the custom tailored code that used to deal with dates and times (mainly in `WebUtils`) has been removed in favor of standard methods in `java.time`
- The `BasicElementFormatter`, which is extended by almost every formatter, has been reviewed and normalized how it deals with dates and times
  - There are new tests that verify and show its behavior
- Date and time formats have been normalize to use the LONG format style for user data and MEDIUM format style for generated data (see the table with examples in #361)

#### Do we need any specific form for testing your changes? If so, please attach one
Nope

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Maybe? We can discuss what should be documented before the release