### PR TITLE
Issue 373 Temporal filters after upgrading to v2.0

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/query/submission/QueryByUIFilterGroup.java
+++ b/src/main/java/org/opendatakit/aggregate/query/submission/QueryByUIFilterGroup.java
@@ -148,15 +148,13 @@ public class QueryByUIFilterGroup extends QueryBase {
             super.addFilter(fem, op, compareValue);
             break;
           case JRDATETIME:
-            if (fem.getFormDataModel() == null && fem.getElementName().contains("meta-"))
-              super.addFilter(fem, op, compareValue);
-            else if (fem.getFormDataModel() != null)
-              super.addFilterChildren(fem, column.getChildColumnCode(), op, compareValue);
-            else
-              throw new IllegalArgumentException("Unrecognized dateTime field");
-            break;
           case JRDATE:
           case JRTIME:
+            if (isLegacyTemporalField(fem))
+              super.addFilter(fem, op, compareValue);
+            else
+              super.addFilterChildren(fem, column.getChildColumnCode(), op, compareValue);
+            break;
           case GEOPOINT:
             super.addFilterChildren(fem, column.getChildColumnCode(), op, compareValue);
             break;
@@ -164,6 +162,11 @@ public class QueryByUIFilterGroup extends QueryBase {
       }
     }
 
+  }
+
+  private boolean isLegacyTemporalField(FormElementModel fem) {
+    return fem.getFormDataModel() == null && fem.getElementName().contains("meta-")
+        || fem.getFormDataModel().getChildren().isEmpty();
   }
 
   public Object getCompareValue(FormElementModel fem, String value) {


### PR DESCRIPTION
Closes #373

#### What has been done to verify that this works as intended?
Manually tested following the instructions on #373.

#### Why is this the best possible solution? Were any other approaches considered?
This PR improves the detection of temporal fields of forms uploaded before upgrading to v2.0
- They can lack their FormElementModel
- They can be metadata fields
- They can have a FormElementModel without child elements

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Yes. The instructions to reproduce the scenario are attached to #373

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.