### PR TITLE
Issue 370 fix date format on dialogs

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/AggregateUI.gwt.xml
+++ b/src/main/java/org/opendatakit/aggregate/AggregateUI.gwt.xml
@@ -13,6 +13,9 @@
   <inherits name='com.google.gwt.maps.Maps'/>
   <!--  v2 <inherits name='com.google.gwt.maps.GoogleMaps' />  -->
   <inherits name='com.google.gwt.visualization.Visualization'/>
+
+  <inherits name='org.opendatakit.common.utils.Utils'/>
+
   <!-- Generic extended widget classes -->
   <inherits name='org.opendatakit.common.web.Web'/>
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
@@ -20,7 +20,6 @@ import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequ
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
@@ -32,6 +31,7 @@ import org.opendatakit.aggregate.client.SecureGWT;
 import org.opendatakit.aggregate.client.form.FormSummary;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
+import org.opendatakit.common.utils.GwtShims;
 
 public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
 
@@ -52,13 +52,12 @@ public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
     AggregateButton confirm = new AggregateButton(BUTTON_TXT, TOOLTIP_TXT, HELP_BALLOON_TXT);
     confirm.addClickHandler(new PurgeHandler());
 
-    String formattedDate = DateTimeFormat.getFormat("MMM dd, yyyy").format(earliest);
     FlexTable layout = new FlexTable();
     SafeHtml content = new SafeHtmlBuilder()
         .appendEscaped("Delete submissions data of ")
         .appendHtmlConstant("<b>" + summary.getTitle() + " [" + summary.getId() + "]</b>")
         .appendEscaped(" up through ")
-        .appendEscaped(formattedDate)
+        .appendEscaped(GwtShims.gwtFormatDateHuman(earliest))
         .appendEscaped(". Incomplete submissions will not be deleted.")
         .toSafeHtml();
     layout.setWidget(0, 0, new HTML(content));
@@ -74,12 +73,11 @@ public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
           SecureGWT.getFormAdminService(),
           (rpc, sessionCookie, cb) -> rpc.purgeSubmissionsData(summary.getId(), earliest, cb),
           (Date result) -> {
-            String formattedDate = DateTimeFormat.getFormat("MMM dd, yyyy").format(result);
             Window.alert("" +
                 "Successful commencement of the purge of:\n" +
                 summary.getTitle() + " [" + summary.getId() + "].\n" +
                 "Deleting all submission data through\n  " +
-                formattedDate + "\n" +
+                GwtShims.gwtFormatDateHuman(result) + "\n" +
                 "Incomplete submissions will not be deleted.");
           },
           cause -> AggregateUI.getUI().reportError("Failed purge of submission data: ", cause)

--- a/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/ConfirmPurgeUpToDatePopup.java
@@ -20,6 +20,7 @@ import static org.opendatakit.aggregate.client.security.SecurityUtils.secureRequ
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
@@ -51,12 +52,13 @@ public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
     AggregateButton confirm = new AggregateButton(BUTTON_TXT, TOOLTIP_TXT, HELP_BALLOON_TXT);
     confirm.addClickHandler(new PurgeHandler());
 
+    String formattedDate = DateTimeFormat.getFormat("MMM dd, yyyy").format(earliest);
     FlexTable layout = new FlexTable();
     SafeHtml content = new SafeHtmlBuilder()
         .appendEscaped("Delete submissions data of ")
         .appendHtmlConstant("<b>" + summary.getTitle() + " [" + summary.getId() + "]</b>")
         .appendEscaped(" up through ")
-        .appendEscaped(earliest.toGMTString())
+        .appendEscaped(formattedDate)
         .appendEscaped(". Incomplete submissions will not be deleted.")
         .toSafeHtml();
     layout.setWidget(0, 0, new HTML(content));
@@ -72,11 +74,12 @@ public class ConfirmPurgeUpToDatePopup extends AbstractPopupBase {
           SecureGWT.getFormAdminService(),
           (rpc, sessionCookie, cb) -> rpc.purgeSubmissionsData(summary.getId(), earliest, cb),
           (Date result) -> {
+            String formattedDate = DateTimeFormat.getFormat("MMM dd, yyyy").format(result);
             Window.alert("" +
                 "Successful commencement of the purge of:\n" +
                 summary.getTitle() + " [" + summary.getId() + "].\n" +
                 "Deleting all submission data through\n  " +
-                result.toGMTString() + "\n" +
+                formattedDate + "\n" +
                 "Incomplete submissions will not be deleted.");
           },
           cause -> AggregateUI.getUI().reportError("Failed purge of submission data: ", cause)

--- a/src/main/java/org/opendatakit/aggregate/client/table/ExportTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/ExportTable.java
@@ -16,6 +16,8 @@
 
 package org.opendatakit.aggregate.client.table;
 
+import static org.opendatakit.common.utils.GwtShims.gwtFormatDateTimeHuman;
+
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.HTML;
@@ -61,7 +63,7 @@ public class ExportTable extends FlexTable {
         this.setText(i + STARTING_ROW, FILE_TYPE, e.getFileType().getDisplayText());
       }
       if (e.getTimeCompleted() != null) {
-        this.setText(i + STARTING_ROW, TIME_COMPLETED, e.getTimeCompleted().toString());
+        this.setText(i + STARTING_ROW, TIME_COMPLETED, gwtFormatDateTimeHuman(e.getTimeCompleted()));
       }
 
       if (e.getStatus() != null) {

--- a/src/main/java/org/opendatakit/aggregate/client/table/PublishTable.java
+++ b/src/main/java/org/opendatakit/aggregate/client/table/PublishTable.java
@@ -17,6 +17,7 @@
 package org.opendatakit.aggregate.client.table;
 
 import static org.opendatakit.aggregate.constants.common.ExternalServiceType.JSON_SERVER;
+import static org.opendatakit.common.utils.GwtShims.gwtFormatDateTimeHuman;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.FlexTable;
@@ -91,8 +92,8 @@ public class PublishTable extends FlexTable {
       if (d == null) {
         d = e.getTimeLastUploadCursor();
       }
-      this.setText(i + STARTING_ROW, LAST_PUBLISHED, (d == null) ? "" : d.toString());
-      this.setText(i + STARTING_ROW, TIME_PUBLISH_START, e.getTimeEstablished().toString());
+      this.setText(i + STARTING_ROW, LAST_PUBLISHED, (d == null) ? "" : gwtFormatDateTimeHuman(d));
+      this.setText(i + STARTING_ROW, TIME_PUBLISH_START, gwtFormatDateTimeHuman(e.getTimeEstablished()));
       this.setText(i + STARTING_ROW, ACTION, e.getPublicationOption().getDescriptionOfOption());
       this.setText(i + STARTING_ROW, TYPE, e.getExternalServiceType().getName());
       this.setWidget(i + STARTING_ROW, OWNERSHIP, new HTML(new SafeHtmlBuilder().appendEscaped(e.getOwnership()).toSafeHtml()));

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/PurgeButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/PurgeButton.java
@@ -18,6 +18,7 @@ package org.opendatakit.aggregate.client.widgets;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
 import java.util.Date;
@@ -83,9 +84,10 @@ public final class PurgeButton extends AggregateButton implements ClickHandler {
             .appendEscaped("not automatically ongoing.  You will need to periodically repeat this process.")
             .appendHtmlConstant("</p>");
       }
+      String formattedDateTime = DateTimeFormat.getFormat("MMM dd, yyyy HH:mm:ss a").format(earliest);
       b.appendEscaped("Click to confirm purge of ")
           .appendHtmlConstant("<b>").appendEscaped(formId).appendHtmlConstant("</b>")
-          .appendEscaped(" submissions older than " + earliest.toString());
+          .appendEscaped(" submissions older than " + formattedDateTime);
 
       // TODO: display pop-up with text from b...
       final ConfirmPurgePopup popup = new ConfirmPurgePopup(externServ, earliest, b.toSafeHtml());

--- a/src/main/java/org/opendatakit/aggregate/client/widgets/PurgeButton.java
+++ b/src/main/java/org/opendatakit/aggregate/client/widgets/PurgeButton.java
@@ -18,13 +18,13 @@ package org.opendatakit.aggregate.client.widgets;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Window;
 import java.util.Date;
 import org.opendatakit.aggregate.client.externalserv.ExternServSummary;
 import org.opendatakit.aggregate.client.popups.ConfirmPurgePopup;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
+import org.opendatakit.common.utils.GwtShims;
 
 public final class PurgeButton extends AggregateButton implements ClickHandler {
 
@@ -84,14 +84,14 @@ public final class PurgeButton extends AggregateButton implements ClickHandler {
             .appendEscaped("not automatically ongoing.  You will need to periodically repeat this process.")
             .appendHtmlConstant("</p>");
       }
-      String formattedDateTime = DateTimeFormat.getFormat("MMM dd, yyyy HH:mm:ss a").format(earliest);
       b.appendEscaped("Click to confirm purge of ")
           .appendHtmlConstant("<b>").appendEscaped(formId).appendHtmlConstant("</b>")
-          .appendEscaped(" submissions older than " + formattedDateTime);
+          .appendEscaped(" submissions older than " + GwtShims.gwtFormatDateTimeHuman(earliest));
 
       // TODO: display pop-up with text from b...
       final ConfirmPurgePopup popup = new ConfirmPurgePopup(externServ, earliest, b.toSafeHtml());
       popup.setPopupPositionAndShow(popup.getPositionCallBack());
     }
   }
+
 }

--- a/src/main/java/org/opendatakit/common/utils/GwtShims.java
+++ b/src/main/java/org/opendatakit/common/utils/GwtShims.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.common.utils;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import java.util.Date;
+
+public class GwtShims {
+  public static String gwtFormatDateHuman(Date date) {
+    return DateTimeFormat.getFormat("MMM dd, yyyy").format(date);
+  }
+
+  public static String gwtFormatDateTimeHuman(Date date) {
+    return DateTimeFormat.getFormat("MMM dd, yyyy HH:mm:ss a").format(date);
+  }
+}

--- a/src/main/java/org/opendatakit/common/utils/Utils.gwt.xml
+++ b/src/main/java/org/opendatakit/common/utils/Utils.gwt.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2019 Nafundi
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN"
+    "https://raw.githubusercontent.com/gwtproject/gwt/2.7.0/distro-source/core/src/gwt-module.dtd">
+<module>
+  <inherits name="com.google.gwt.user.User"/>
+
+  <source path="" includes="GwtShims.java"/>
+</module>


### PR DESCRIPTION
Closes #370

#### What has been done to verify that this works as intended?
- Manually checked correct date formats on the purge dialogs (submissions and publishers)
- Manually checked correct dateTime formats on the export and publisher tables

#### Why is this the best possible solution? Were any other approaches considered?
The *best* solution would be that GWT emulates `java.time` and we can reuse JRTemporal on the client but, unfortunately, it doesn't.

I've reproduced the same formats on a new GwtShims class, which is reused across the web UI.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Yes, along with other changes in v2.0