### PR TITLE
Issue 379 Fix bug in fixOffset method

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -412,7 +412,7 @@ public class BaseFormParserForJavaRosa {
         return new Date();
       ++endIdx;
       String timestamp = xml.substring(idx + ODK_TIMESTAMP_COMMENT.length(), endIdx);
-      Date d = Date.from(OffsetDateTime.parse(fixOffset(timestamp)).toInstant());
+      Date d = Date.from(OffsetDateTime.parse(fixOffset(timestamp.trim())).toInstant());
       if (d != null) {
         return d;
       } else {
@@ -1051,9 +1051,16 @@ public class BaseFormParserForJavaRosa {
     XFORMS_MISSING_VERSION, XFORMS_EARLIER_VERSION
   }
 
-  private static String fixOffset(String raw) {
+  static String fixOffset(String raw) {
+    // Offsets can come in +00 or -00 format. They need to be converted to +00:00 and -00:00
     char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
-    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
+    if (thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-')
+      return raw + ":00";
+    // Offsets can come in +0000 or -0000 format. They need to be converted to +00:00 and -00:00
+    char fifthCharFromTheEnd = raw.charAt(raw.length() - 5);
+    if (fifthCharFromTheEnd == '+' || fifthCharFromTheEnd == '-')
+      return raw.substring(0, raw.length() - 2) + ":" + raw.substring(raw.length() - 2);
+    return raw;
   }
 
 }

--- a/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
+++ b/src/main/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosa.java
@@ -23,6 +23,7 @@ import static org.opendatakit.aggregate.constants.ParserConsts.FORM_ID_ATTRIBUTE
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH;
 import static org.opendatakit.aggregate.constants.ParserConsts.FORWARD_SLASH_SUBSTITUTION;
 import static org.opendatakit.aggregate.constants.ParserConsts.NAMESPACE_ODK;
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporalUtils.parseDate;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -412,7 +413,7 @@ public class BaseFormParserForJavaRosa {
         return new Date();
       ++endIdx;
       String timestamp = xml.substring(idx + ODK_TIMESTAMP_COMMENT.length(), endIdx);
-      Date d = Date.from(OffsetDateTime.parse(fixOffset(timestamp.trim())).toInstant());
+      Date d = parseDate(timestamp);
       if (d != null) {
         return d;
       } else {
@@ -1049,18 +1050,6 @@ public class BaseFormParserForJavaRosa {
     XFORMS_DIFFERENT, // instances differ significantly enough to affect
     // database schema
     XFORMS_MISSING_VERSION, XFORMS_EARLIER_VERSION
-  }
-
-  static String fixOffset(String raw) {
-    // Offsets can come in +00 or -00 format. They need to be converted to +00:00 and -00:00
-    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
-    if (thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-')
-      return raw + ":00";
-    // Offsets can come in +0000 or -0000 format. They need to be converted to +00:00 and -00:00
-    char fifthCharFromTheEnd = raw.charAt(raw.length() - 5);
-    if (fifthCharFromTheEnd == '+' || fifthCharFromTheEnd == '-')
-      return raw.substring(0, raw.length() - 2) + ":" + raw.substring(raw.length() - 2);
-    return raw;
   }
 
 }

--- a/src/main/java/org/opendatakit/aggregate/servlet/FragmentedCsvServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/FragmentedCsvServlet.java
@@ -18,10 +18,10 @@
 
 package org.opendatakit.aggregate.servlet;
 
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporalUtils.parseDate;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -263,7 +263,7 @@ public class FragmentedCsvServlet extends ServletUtilBase {
 
         if (!submissions.isEmpty()) {
           QueryResumePoint resumeCursor = query.getResumeCursor();
-          Date resumeDate = Date.from(OffsetDateTime.parse(fixOffset(resumeCursor.getValue())).toInstant());
+          Date resumeDate = parseDate(resumeCursor.getValue());
           websafeCursorString = Long.toString(resumeDate.getTime())
               + " and " + resumeCursor.getUriLastReturnedValue();
         } else {
@@ -293,10 +293,4 @@ public class FragmentedCsvServlet extends ServletUtilBase {
       errorRetreivingData(resp);
     }
   }
-
-  private static String fixOffset(String raw) {
-    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
-    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
-  }
-
 }

--- a/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalUtils.java
@@ -16,13 +16,29 @@
 
 package org.opendatakit.aggregate.submission.type.jr;
 
-final class JRTemporalUtils {
+import java.time.OffsetDateTime;
+import java.util.Date;
+
+public final class JRTemporalUtils {
   private JRTemporalUtils() {
     // Prevent instantiation of this class
   }
 
-  static String fixOffset(String raw) {
+  public static String fixOffset(String raw) {
+    // Trim the input string to prevent errors from leading or trailing spaces that might be present
+    raw = raw.trim();
+    // Offsets can come in +00 or -00 format. They need to be converted to +00:00 and -00:00
     char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
-    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
+    if (thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-')
+      return raw + ":00";
+    // Offsets can come in +0000 or -0000 format. They need to be converted to +00:00 and -00:00
+    char fifthCharFromTheEnd = raw.charAt(raw.length() - 5);
+    if (fifthCharFromTheEnd == '+' || fifthCharFromTheEnd == '-')
+      return raw.substring(0, raw.length() - 2) + ":" + raw.substring(raw.length() - 2);
+    return raw;
+  }
+
+  public static Date parseDate(String raw) {
+    return Date.from(OffsetDateTime.parse(fixOffset(raw)).toInstant());
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/util/DateTimeUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/util/DateTimeUtils.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.util;
+
+public class DateTimeUtils {
+
+}

--- a/src/main/java/org/opendatakit/common/persistence/engine/EngineUtils.java
+++ b/src/main/java/org/opendatakit/common/persistence/engine/EngineUtils.java
@@ -19,6 +19,7 @@ package org.opendatakit.common.persistence.engine;
 
 import static java.time.ZoneId.systemDefault;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporalUtils.parseDate;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -192,7 +193,7 @@ public class EngineUtils {
         if (v == null) {
           value = null;
         } else {
-          value = Date.from(OffsetDateTime.parse(fixOffset(v)).toInstant());
+          value = parseDate(v);
         }
         break;
       }
@@ -200,11 +201,6 @@ public class EngineUtils {
         throw new IllegalStateException("datatype not handled");
     }
     return value;
-  }
-
-  private static String fixOffset(String raw) {
-    char thirdCharFromTheEnd = raw.charAt(raw.length() - 3);
-    return thirdCharFromTheEnd == '+' || thirdCharFromTheEnd == '-' ? raw + ":00" : raw;
   }
 
 }

--- a/src/test/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosaTest.java
+++ b/src/test/java/org/opendatakit/aggregate/parser/BaseFormParserForJavaRosaTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate.parser;
+
+import static org.junit.Assert.assertThat;
+import static org.opendatakit.aggregate.parser.BaseFormParserForJavaRosa.fixOffset;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class BaseFormParserForJavaRosaTest {
+
+  @Test
+  public void fixes_wrong_offsets_in_iso8601_datetimes() {
+    assertThat(fixOffset("00:00:00.000Z"), Matchers.is("00:00:00.000Z"));
+    assertThat(fixOffset("00:00:00.000+00"), Matchers.is("00:00:00.000+00:00"));
+    assertThat(fixOffset("00:00:00.000+01"), Matchers.is("00:00:00.000+01:00"));
+    assertThat(fixOffset("00:00:00.000+0000"), Matchers.is("00:00:00.000+00:00"));
+    assertThat(fixOffset("00:00:00.000+1122"), Matchers.is("00:00:00.000+11:22"));
+    assertThat(fixOffset("00:00:00.000-00"), Matchers.is("00:00:00.000-00:00"));
+    assertThat(fixOffset("00:00:00.000-01"), Matchers.is("00:00:00.000-01:00"));
+    assertThat(fixOffset("00:00:00.000-0000"), Matchers.is("00:00:00.000-00:00"));
+    assertThat(fixOffset("00:00:00.000-1122"), Matchers.is("00:00:00.000-11:22"));
+  }
+}

--- a/src/test/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalUtilsTest.java
+++ b/src/test/java/org/opendatakit/aggregate/submission/type/jr/JRTemporalUtilsTest.java
@@ -14,15 +14,15 @@
  * the License.
  */
 
-package org.opendatakit.aggregate.parser;
+package org.opendatakit.aggregate.submission.type.jr;
 
 import static org.junit.Assert.assertThat;
-import static org.opendatakit.aggregate.parser.BaseFormParserForJavaRosa.fixOffset;
+import static org.opendatakit.aggregate.submission.type.jr.JRTemporalUtils.fixOffset;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-public class BaseFormParserForJavaRosaTest {
+public class JRTemporalUtilsTest {
 
   @Test
   public void fixes_wrong_offsets_in_iso8601_datetimes() {


### PR DESCRIPTION
Closes #379

#### What has been done to verify that this works as intended?
- Pushed a form with the `-fsb` flag to enforce parsing the blank form again
- Added new unit tests to verify the change and prevent regression

#### Why is this the best possible solution? Were any other approaches considered?
This is a small change to consider another case where incoming datetime's offset data string should be fixed to a standard iso8601 format.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.