### PR TITLE
Issue 380 Fix geopoint formatting when it lacks alt or acc components

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
+++ b/src/main/java/org/opendatakit/aggregate/format/element/BasicElementFormatter.java
@@ -116,25 +116,30 @@ public class BasicElementFormatter implements ElementFormatter {
       return;
     }
 
+    Optional<String> maybeLatitude = Optional.ofNullable(value).map(GeoPoint::getLatitude).map(WrappedBigDecimal::toString);
+    Optional<String> maybeLongitude = Optional.ofNullable(value).map(GeoPoint::getLongitude).map(WrappedBigDecimal::toString);
+    Optional<String> maybeAltitude = Optional.ofNullable(value).map(GeoPoint::getAltitude).map(WrappedBigDecimal::toString);
+    Optional<String> maybeAccuracy = Optional.ofNullable(value).map(GeoPoint::getAccuracy).map(WrappedBigDecimal::toString);
+
     if (separateCoordinates) {
-      row.addFormattedValue(value.getLatitude().toString());
-      row.addFormattedValue(value.getLongitude().toString());
+      row.addFormattedValue(maybeLatitude.orElse(null));
+      row.addFormattedValue(maybeLongitude.orElse(null));
       if (includeAltitude)
-        row.addFormattedValue(value.getAltitude().toString());
+        row.addFormattedValue(maybeAltitude.orElse(null));
       if (includeAccuracy)
-        row.addFormattedValue(value.getAccuracy().toString());
+        row.addFormattedValue(maybeAccuracy.orElse(null));
       return;
     }
 
-    if (value.getLongitude() != null && value.getLatitude() != null) {
-      List<WrappedBigDecimal> parts = new ArrayList<>();
-      parts.add(value.getLatitude());
-      parts.add(value.getLongitude());
-      if (includeAltitude)
-        parts.add(value.getAltitude());
-      if (includeAccuracy)
-        parts.add(value.getAccuracy());
-      row.addFormattedValue(parts.stream().map(WrappedBigDecimal::toString).collect(joining(", ")));
+    if (maybeLongitude.isPresent() && maybeLatitude.isPresent()) {
+      List<String> parts = new ArrayList<>();
+      parts.add(maybeLatitude.orElse(""));
+      parts.add(maybeLongitude.orElse(""));
+      if (includeAltitude && maybeAltitude.isPresent())
+        parts.add(maybeAltitude.orElse(""));
+      if (includeAccuracy && maybeAccuracy.isPresent())
+        parts.add(maybeAccuracy.orElse(""));
+      row.addFormattedValue(String.join(", ", parts));
     }
 
   }

--- a/src/test/java/org/opendatakit/aggregate/format/element/BasicElementFormatterTest.java
+++ b/src/test/java/org/opendatakit/aggregate/format/element/BasicElementFormatterTest.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
 import org.junit.Test;
 import org.opendatakit.aggregate.format.Row;
@@ -107,11 +108,13 @@ public class BasicElementFormatterTest {
   @Test
   public void formatsgeopoints() {
     assertThat(format(null, false, false), is(nullValue()));
+    assertThat(format(geopoint(1, 2, null, null), true, true), is("1.0, 2.0"));
     assertThat(format(geopoint(1, 2, 3, 4), false, false), is("1.0, 2.0"));
     assertThat(format(geopoint(1, 2, 3, 4), true, false), is("1.0, 2.0, 3.0"));
     assertThat(format(geopoint(1, 2, 3, 4), false, true), is("1.0, 2.0, 4.0")); // Oopsie, this doesn't make much sense...
     assertThat(format(geopoint(1, 2, 3, 4), true, true), is("1.0, 2.0, 3.0, 4.0"));
     assertThat(formatSeparated(null, false, false), contains(nullValue()));
+    assertThat(formatSeparated(geopoint(1, 2, null, null), true, true), contains("1.0", "2.0", null, null));
     assertThat(formatSeparated(geopoint(1, 2, 3, 4), false, false), contains("1.0", "2.0"));
     assertThat(formatSeparated(geopoint(1, 2, 3, 4), true, false), contains("1.0", "2.0", "3.0"));
     assertThat(formatSeparated(geopoint(1, 2, 3, 4), false, true), contains("1.0", "2.0", "4.0")); // Oopsie, this doesn't make much sense...
@@ -132,10 +135,10 @@ public class BasicElementFormatterTest {
 
   private GeoPoint geopoint(Number lat, Number lon, Number alt, Number acc) {
     return new GeoPoint(
-        WrappedBigDecimal.fromDouble(lat.doubleValue()),
-        WrappedBigDecimal.fromDouble(lon.doubleValue()),
-        WrappedBigDecimal.fromDouble(alt.doubleValue()),
-        WrappedBigDecimal.fromDouble(acc.doubleValue())
+        Optional.ofNullable(lat).map(Number::doubleValue).map(WrappedBigDecimal::fromDouble).orElse(null),
+        Optional.ofNullable(lon).map(Number::doubleValue).map(WrappedBigDecimal::fromDouble).orElse(null),
+        Optional.ofNullable(alt).map(Number::doubleValue).map(WrappedBigDecimal::fromDouble).orElse(null),
+        Optional.ofNullable(acc).map(Number::doubleValue).map(WrappedBigDecimal::fromDouble).orElse(null)
     );
   }
 


### PR DESCRIPTION
Closes #380

#### What has been done to verify that this works as intended?
Added new test cases to verify that we can format geopoints that lack altutide or accuracy components

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change I could come up that takes into account that a geopoint value, and its lat, lon, alt, and acc can be `null`.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
No. Any form with geopoints will do.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.