### PR TITLE
Issue 391 fix http 302 redirects behind proxy

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/HttpUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/HttpUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.aggregate;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class HttpUtils {
+  public static void redirect(HttpServletResponse resp, String url) {
+    // Can't use resp.sendRedirect() because it messes up
+    // the domain and ports when Aggregate is running behind a proxy
+    resp.setStatus(302);
+    resp.setHeader("Location", url);
+  }
+}

--- a/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.opendatakit.aggregate.ContextFactory;
+import org.opendatakit.aggregate.HttpUtils;
 import org.opendatakit.aggregate.constants.common.UIConsts;
 import org.opendatakit.aggregate.server.ServerPreferencesProperties;
 import org.opendatakit.common.persistence.Datastore;
@@ -105,7 +106,7 @@ public class AggregateHtmlServlet extends ServletUtilBase {
     if (!url.getHost().equalsIgnoreCase(req.getServerName())) {
       // we should redirect over to the proper fully-formed URL.
       logger.info("Incoming servername: " + req.getServerName() + " expected: " + url.getHost() + " -- redirecting.");
-      resp.sendRedirect(newUrl);
+      HttpUtils.redirect(resp, newUrl);
       return;
     }
 
@@ -139,7 +140,7 @@ public class AggregateHtmlServlet extends ServletUtilBase {
       if (directToConfigTab) {
         newUrl += "#admin/permission///";
         logger.info("Redirect to configuration tab: " + newUrl);
-        resp.sendRedirect(newUrl);
+        HttpUtils.redirect(resp, newUrl);
         return;
       }
     }

--- a/src/main/java/org/opendatakit/aggregate/servlet/ClearSessionThenLoginServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ClearSessionThenLoginServlet.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.opendatakit.aggregate.ContextFactory;
+import org.opendatakit.aggregate.HttpUtils;
 import org.opendatakit.common.security.UserService;
 import org.opendatakit.common.web.CallingContext;
 
@@ -62,17 +63,17 @@ public class ClearSessionThenLoginServlet extends ServletUtilBase {
     String newUrl;
     if (isAnon) {
       // anonymous user -- go to the login page...
-      newUrl = cc.getWebApplicationURL("multimode_login.html");
+      newUrl = "/multimode_login.html";
     } else {
       // we are logged in via token-based or basic or digest auth.
       // redirect to Spring's logout url...
-      newUrl = cc.getWebApplicationURL(cc.getUserService().createLogoutURL());
+      newUrl = "/" + cc.getUserService().createLogoutURL();
     }
     // preserve the query string (helps with GWT debugging)
     String query = req.getQueryString();
     if (query != null && query.length() != 0) {
       newUrl += "?" + query;
     }
-    resp.sendRedirect(newUrl);
+    HttpUtils.redirect(resp, newUrl);
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/servlet/MultimodeLoginPageServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/MultimodeLoginPageServlet.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.opendatakit.aggregate.ContextFactory;
+import org.opendatakit.aggregate.HttpUtils;
 import org.opendatakit.common.web.CallingContext;
 import org.opendatakit.common.web.constants.BasicConsts;
 import org.opendatakit.common.web.constants.HtmlConsts;
@@ -71,7 +72,7 @@ public class MultimodeLoginPageServlet extends ServletUtilBase {
         e.printStackTrace();
       }
       // go to the proper page (we'll most likely be redirected back to here for authentication)
-      resp.sendRedirect(newUrl);
+      HttpUtils.redirect(resp, newUrl);
       return;
     }
 
@@ -89,7 +90,7 @@ public class MultimodeLoginPageServlet extends ServletUtilBase {
     }
 
     // check for XSS attacks. The redirect string is emitted within single and double
-    // quotes. It is a URL with :, /, ? and # characters. But it should not contain 
+    // quotes. It is a URL with :, /, ? and # characters. But it should not contain
     // quotes, parentheses or semicolons.
     String cleanString = redirectParamString.replaceAll(BAD_PARAMETER_CHARACTERS, "");
     if (!cleanString.equals(redirectParamString)) {

--- a/src/main/java/org/opendatakit/common/security/server/SecurityServiceImpl.java
+++ b/src/main/java/org/opendatakit/common/security/server/SecurityServiceImpl.java
@@ -111,8 +111,7 @@ public class SecurityServiceImpl extends RemoteServiceServlet implements
       throw new DatastoreFailureException("Unable to access datastore");
     }
     // User interface layer uses this URL to submit password changes securely
-    r.setChangeUserPasswordURL(cc.getSecureServerURL() + BasicConsts.FORWARDSLASH
-        + UserManagePasswordsServlet.ADDR);
+    r.setChangeUserPasswordURL("/" + UserManagePasswordsServlet.ADDR);
     return r;
   }
 }


### PR DESCRIPTION
Closes #391

Build on top of #390. See just the last commit

#### What has been done to verify that this works as intended?
To check that this works, you have to verify that logging in and changing the administrator password works as expected.

I've verified it in the local dev server (gradle), with the local cloudconfig stack.

I'm testing it on DO as well. Will update this when I get the results.

#### Why is this the best possible solution? Were any other approaches considered?

This bug is related to how Swing builds redirection URLs with the `HttpServletResponse.sendRedirect()` method.

When Aggregate is running behind a proxy, the URLs Swing generates have the wrong domain, wrong port, or they can lack the port number, which won't work.

After searching for uses of `sendRedirect()` in the code, I've seen a few of them that could be replaced by manually setting the redirection response:
- set the status to 302
- set a `Location` header with an absolute path, but without setting the domain&port

  This works around the issue, and it doesn't affect to normal Aggregate setups without proxies.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.