### PR TITLE
Fix Cloud-Config scripts

### DIFF
--- a/cloud-config/assets/cloud-config.yml
+++ b/cloud-config/assets/cloud-config.yml
@@ -65,8 +65,6 @@ write_files:
       chmod +x /usr/local/bin/aggregate-cli
 
 runcmd:
-  - service nginx stop
-
   - download-aggregate-cli
 
   - apt-get -y remove openjdk-11-jre-headless
@@ -87,6 +85,6 @@ runcmd:
   - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
   - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
-  - aggregate-cli -i -ip -c /root/aggregate-config.json
+  - aggregate-cli -i -ip -y -c /root/aggregate-config.json
 
-  - service nginx start
+  - service nginx restart

--- a/cloud-config/digital-ocean/README.md
+++ b/cloud-config/digital-ocean/README.md
@@ -4,11 +4,11 @@ This Cloud-Config setup is intended to be used with Ubuntu 18.04 droplets in [Di
 
 #### Create your Droplet
 
-If you haven't already created an account, use this link to do so: https://m.do.co/c/39937689124c
+If you haven't already created a DigitalOcean account, use our referral link to do so: https://m.do.co/c/39937689124c. 
 
-DigitalOcean will give you $100 of credit to spend during the first 60 days so that you can try things out and select what better fits to your workload.
+DigitalOcean will give you $100 of credit to spend during the first 60 days so that you can try things out. Once you've spent $25 with them, we'll get $25 to put towards our hosting costs.
 
-1. Log into https://www.digitalocean.com and create a new Droplet.
+1. Log into Digital Ocean and create a new Droplet.
   
 1. Select the distribution for your new Droplet: Select the option `18.04 x64` from the Ubuntu box.
 

--- a/cloud-config/digital-ocean/README.md
+++ b/cloud-config/digital-ocean/README.md
@@ -4,6 +4,10 @@ This Cloud-Config setup is intended to be used with Ubuntu 18.04 droplets in [Di
 
 #### Create your Droplet
 
+If you haven't already created an account, use this link to do so: https://m.do.co/c/39937689124c
+
+DigitalOcean will give you $100 of credit to spend during the first 60 days so that you can try things out and select what better fits to your workload.
+
 1. Log into https://www.digitalocean.com and create a new Droplet.
   
 1. Select the distribution for your new Droplet: Select the option `18.04 x64` from the Ubuntu box.

--- a/cloud-config/virtualbox/cloud-config.tpl.yml
+++ b/cloud-config/virtualbox/cloud-config.tpl.yml
@@ -58,23 +58,21 @@ write_files:
               proxy_pass http://127.0.0.1:8080;
           }
       }
-  - path: /usr/local/bin/download-aggregate-updater
+  - path: /usr/local/bin/download-aggregate-cli
     permissions: '0755'
     content: |
       #!/bin/sh
-      curl -s https://api.github.com/repos/opendatakit/aggregate-updater/releases/latest \
-      | grep "aggregate-updater.zip" \
+      curl -s https://api.github.com/repos/opendatakit/aggregate-cli/releases/latest \
+      | grep "aggregate-cli.zip" \
       | cut -d: -f 2,3 \
       | tr -d \" \
-      | wget -O /tmp/aggregate-updater.zip -qi -
+      | wget -O /tmp/aggregate-cli.zip -qi -
 
-      unzip /tmp/aggregate-updater.zip -d /usr/local/bin
-      chmod +x /usr/local/bin/aggregate-updater
+      unzip /tmp/aggregate-cli.zip -d /usr/local/bin
+      chmod +x /usr/local/bin/aggregate-cli
 
 runcmd:
-  - service nginx stop
-
-  - download-aggregate-updater
+  - download-aggregate-cli
 
   - apt-get -y remove openjdk-11-jre-headless
 
@@ -87,6 +85,6 @@ runcmd:
   - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
   - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
-  - aggregate-updater -i -ip -c /root/aggregate-config.json
+  - aggregate-cli -i -ip -y -c /root/aggregate-config.json
 
-  - service nginx start
+  - service nginx restart


### PR DESCRIPTION
This PR fixes the Cloud-Config scripts to use proper urls and names for the Aggregate CLI v1.0.3
  - After the change from `aggregate-updater` to `aggregate-cli`, there were still some spots in the CloudConfig stacks pending to be changed

#### What has been done to verify that this works as intended?
Run the stack on VirtualBox and DO and verify that it runs the installer CLI op.

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?

#### Do we need any specific form for testing your changes? If so, please attach one

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.