### PR TITLE
Issue 401 check hostnames conditionally

### DIFF
--- a/cloud-config/assets/cloud-config.yml
+++ b/cloud-config/assets/cloud-config.yml
@@ -86,6 +86,6 @@ runcmd:
   - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
   - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
-  - aggregate-cli -i -ip -y -c /root/aggregate-config.json
+  - aggregate-cli -i -y -c /root/aggregate-config.json
 
   - service nginx restart

--- a/cloud-config/assets/cloud-config.yml
+++ b/cloud-config/assets/cloud-config.yml
@@ -33,7 +33,8 @@ write_files:
         "security": {
           "forceHttpsLinks": true,
           "port": 80,
-          "securePort": 443
+          "securePort": 443,
+          "checkHostnames": false
         },
         "tomcat": {
           "uid": "tomcat8",

--- a/cloud-config/assets/cloud-config.yml
+++ b/cloud-config/assets/cloud-config.yml
@@ -31,6 +31,7 @@ write_files:
           "password": "aggregate"
         },
         "security": {
+          "hostname": "foo.bar",
           "forceHttpsLinks": true,
           "port": 80,
           "securePort": 443,
@@ -72,7 +73,6 @@ runcmd:
 
   - rm /etc/nginx/sites-enabled/default
   - mv /tmp/nginx-aggregate /etc/nginx/sites-enabled/aggregate
-  - sed -i -e 's/server_name foo\.bar;/server_name '"$(curl http://169.254.169.254/metadata/v1/hostname)"';/' /etc/nginx/sites-enabled/aggregate
 
   - add-apt-repository -y universe
   - add-apt-repository -y ppa:certbot/certbot
@@ -85,6 +85,9 @@ runcmd:
   - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE aggregate TO aggregate\""
   - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
   - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
+
+  - sed -i -e 's/foo\.bar/'"$(curl http://169.254.169.254/metadata/v1/hostname)"/' /root/aggregate-config.json
+  - sed -i -e 's/foo\.bar/'"$(curl http://169.254.169.254/metadata/v1/hostname)"/' /etc/nginx/sites-enabled/aggregate
 
   - aggregate-cli -i -y -c /root/aggregate-config.json
 

--- a/cloud-config/virtualbox/cloud-config.tpl.yml
+++ b/cloud-config/virtualbox/cloud-config.tpl.yml
@@ -40,7 +40,8 @@ write_files:
         "security": {
           "forceHttpsLinks": false,
           "port": 10080,
-          "securePort": 443
+          "securePort": 443,
+          "checkHostnames": false
         },
         "tomcat": {
           "uid": "tomcat8",

--- a/cloud-config/virtualbox/cloud-config.tpl.yml
+++ b/cloud-config/virtualbox/cloud-config.tpl.yml
@@ -38,6 +38,7 @@ write_files:
           "password": "aggregate"
         },
         "security": {
+          "hostname": "{{hostIp}}",
           "forceHttpsLinks": false,
           "port": 10080,
           "securePort": 443,

--- a/docs/aggregate-config.md
+++ b/docs/aggregate-config.md
@@ -68,6 +68,15 @@ This file supports the following configuration settings:
   
   Set this to the security realm you want your users to see when logging into Aggregate   
 
+**security.server.checkHostnames*
+- Accepted values: `true`, `false`
+- Default value: `true`
+  
+  Set to `false` if you're running Aggregate behind a proxy or a load balancer to avoid infinite redirects.
+  
+  When set to `true`, Aggregate will always check the request's hostname and redirect to the configured or detected hostname (`security.server.hostname`) if they don't match.
+
+
 ## Database configuration
 
 Please refer to [Database configurations](database-configurations.md) document where this is covered in detail.

--- a/docs/aggregate-config.md
+++ b/docs/aggregate-config.md
@@ -24,7 +24,7 @@ This file supports the following configuration settings:
   
   The `REQUIRES_SECURE_CHANNEL` requires to set up SSL in your server.
     
-**security.server.forceHttpsLinks*
+**security.server.forceHttpsLinks**
 - Accepted values: `true`, `false`
 - Default value: `false`
   
@@ -68,7 +68,7 @@ This file supports the following configuration settings:
   
   Set this to the security realm you want your users to see when logging into Aggregate   
 
-**security.server.checkHostnames*
+**security.server.checkHostnames**
 - Accepted values: `true`, `false`
 - Default value: `true`
   

--- a/installer/project/files/conf/mysql/odk-settings.xml
+++ b/installer/project/files/conf/mysql/odk-settings.xml
@@ -51,6 +51,7 @@
     <property name="channelType" value="${security.server.channelType}"/>
     <property name="secureChannelType" value="${security.server.secureChannelType}"/>
     <property name="forceHttpsLinks" value="${security.server.forceHttpsLinks:false}"/>
+    <property name="checkHostnames" value="${security.server.checkHostnames:true}"/>
   </bean>
 
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">

--- a/installer/project/files/conf/postgresql/odk-settings.xml
+++ b/installer/project/files/conf/postgresql/odk-settings.xml
@@ -51,6 +51,7 @@
     <property name="channelType" value="${security.server.channelType}"/>
     <property name="secureChannelType" value="${security.server.secureChannelType}"/>
     <property name="forceHttpsLinks" value="${security.server.forceHttpsLinks:false}"/>
+    <property name="checkHostnames" value="${security.server.checkHostnames:true}"/>
   </bean>
 
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">

--- a/installer/project/files/conf/sqlserver/odk-settings.xml
+++ b/installer/project/files/conf/sqlserver/odk-settings.xml
@@ -52,6 +52,7 @@
     <property name="channelType" value="${security.server.channelType}"/>
     <property name="secureChannelType" value="${security.server.secureChannelType}"/>
     <property name="forceHttpsLinks" value="${security.server.forceHttpsLinks:false}"/>
+    <property name="checkHostnames" value="${security.server.checkHostnames:true}"/>
   </bean>
 
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">

--- a/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
@@ -94,20 +94,22 @@ public class AggregateHtmlServlet extends ServletUtilBase {
     User user = cc.getCurrentUser();
     UserService userService = cc.getUserService();
 
-    // Check to make sure we are using the canonical server name.
-    // If not, redirect to that name.  This ensures that authentication
-    // cookies will have the proper realm(s) established for them.
     String newUrl = cc.getServerURL() + BasicConsts.FORWARDSLASH + ADDR;
     String query = req.getQueryString();
     if (query != null && query.length() != 0) {
       newUrl += "?" + query;
     }
-    URL url = new URL(newUrl);
-    if (!url.getHost().equalsIgnoreCase(req.getServerName())) {
-      // we should redirect over to the proper fully-formed URL.
-      logger.info("Incoming servername: " + req.getServerName() + " expected: " + url.getHost() + " -- redirecting.");
-      HttpUtils.redirect(resp, newUrl);
-      return;
+    if (userService.getCurrentRealm().getCheckHostnames()) {
+      // Check to make sure we are using the canonical server name.
+      // If not, redirect to that name.  This ensures that authentication
+      // cookies will have the proper realm(s) established for them.
+      URL url = new URL(newUrl);
+      if (!url.getHost().equalsIgnoreCase(req.getServerName())) {
+        // we should redirect over to the proper fully-formed URL.
+        logger.info("Incoming servername: " + req.getServerName() + " expected: " + url.getHost() + " -- redirecting.");
+        HttpUtils.redirect(resp, newUrl);
+        return;
+      }
     }
 
     // OK. We are using the canonical server name.

--- a/src/main/java/org/opendatakit/aggregate/servlet/MultimodeLoginPageServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/MultimodeLoginPageServlet.java
@@ -51,29 +51,31 @@ public class MultimodeLoginPageServlet extends ServletUtilBase {
       IOException {
     CallingContext cc = ContextFactory.getCallingContext(this, req);
 
-    // Check to make sure we are using the canonical server name.
-    // If not, redirect to that name.  This ensures that authentication
-    // cookies will have the proper realm(s) established for them.
-    String newUrl = cc.getServerURL() + BasicConsts.FORWARDSLASH + ADDR;
-    String query = req.getQueryString();
-    if (query != null && query.length() != 0) {
-      newUrl += "?" + query;
-    }
-    URL url = new URL(newUrl);
-    if (!url.getHost().equalsIgnoreCase(req.getServerName())) {
-      logger.info("Incoming servername: " + req.getServerName() + " expected: " + url.getHost() + " -- redirecting.");
-      // try to get original destination URL from Spring...
-      String redirectUrl = getRedirectUrl(req, ADDR);
-      try {
-        URI uriChangeable = new URI(redirectUrl);
-        URI newUri = new URI(url.getProtocol(), null, url.getHost(), url.getPort(), uriChangeable.getPath(), uriChangeable.getQuery(), uriChangeable.getFragment());
-        newUrl = newUri.toString();
-      } catch (URISyntaxException e) {
-        e.printStackTrace();
+    if (cc.getUserService().getCurrentRealm().getCheckHostnames()) {
+      // Check to make sure we are using the canonical server name.
+      // If not, redirect to that name.  This ensures that authentication
+      // cookies will have the proper realm(s) established for them.
+      String newUrl = cc.getServerURL() + BasicConsts.FORWARDSLASH + ADDR;
+      String query = req.getQueryString();
+      if (query != null && query.length() != 0) {
+        newUrl += "?" + query;
       }
-      // go to the proper page (we'll most likely be redirected back to here for authentication)
-      HttpUtils.redirect(resp, newUrl);
-      return;
+      URL url = new URL(newUrl);
+      if (!url.getHost().equalsIgnoreCase(req.getServerName())) {
+        logger.info("Incoming servername: " + req.getServerName() + " expected: " + url.getHost() + " -- redirecting.");
+        // try to get original destination URL from Spring...
+        String redirectUrl = getRedirectUrl(req, ADDR);
+        try {
+          URI uriChangeable = new URI(redirectUrl);
+          URI newUri = new URI(url.getProtocol(), null, url.getHost(), url.getPort(), uriChangeable.getPath(), uriChangeable.getQuery(), uriChangeable.getFragment());
+          newUrl = newUri.toString();
+        } catch (URISyntaxException e) {
+          e.printStackTrace();
+        }
+        // go to the proper page (we'll most likely be redirected back to here for authentication)
+        HttpUtils.redirect(resp, newUrl);
+        return;
+      }
     }
 
     // OK. We are using the canonical server name.

--- a/src/main/java/org/opendatakit/common/security/Realm.java
+++ b/src/main/java/org/opendatakit/common/security/Realm.java
@@ -38,6 +38,7 @@ public class Realm implements InitializingBean {
   private String hostname;
   private String realmString;
   private boolean isGaeEnvironment = false;
+  private boolean checkHostnames = true;
 
   public Realm() {
   }
@@ -57,6 +58,7 @@ public class Realm implements InitializingBean {
     log.info("ForceHttpsLinks: " + (forceHttpsLinks ? "yes" : "no"));
     log.info("RealmString: " + realmString);
     log.info("isGaeEnvironment: " + (isGaeEnvironment ? "yes" : "no"));
+    log.info("CheckHostnames: " + (checkHostnames ? "yes" : "no"));
     log.info("java.library.path: " + System.getProperty("java.library.path"));
   }
 
@@ -128,4 +130,11 @@ public class Realm implements InitializingBean {
     this.forceHttpsLinks = forceHttpsLinks;
   }
 
+  public boolean getCheckHostnames() {
+    return checkHostnames;
+  }
+
+  public void setCheckHostnames(boolean checkHostnames) {
+    this.checkHostnames = checkHostnames;
+  }
 }

--- a/src/main/resources/odk-settings.xml.example
+++ b/src/main/resources/odk-settings.xml.example
@@ -48,6 +48,7 @@
     <property name="channelType" value="${security.server.channelType}"/>
     <property name="secureChannelType" value="${security.server.secureChannelType}"/>
     <property name="forceHttpsLinks" value="${security.server.forceHttpsLinks:false}"/>
+    <property name="checkHostnames" value="${security.server.checkHostnames:true}"/>
   </bean>
 
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">

--- a/src/main/resources/security.properties.example
+++ b/src/main/resources/security.properties.example
@@ -7,3 +7,4 @@ security.server.port=8080
 security.server.securePort=8443
 security.server.superUserUsername=administrator
 security.server.realm.realmString=ODK Aggregate
+security.server.checkHostnames=true


### PR DESCRIPTION
Closes #401

Also fixes the Cloud-Config stack to install only releases (remove the `--include-pre-releases` flag from the aggregate-cli install command)

#### What has been done to verify that this works as intended?
Run locally with the Cloud-Config stack for VirtualBox
Upload a [Simple Form](https://github.com/opendatakit/briefcase/blob/master/test/resources/org/opendatakit/briefcase/export/simple-form.xml), a [Media Files](https://github.com/opendatakit/briefcase/blob/master/test/resources/org/opendatakit/briefcase/export/media-files.xml) form, and [Birds](https://github.com/opendatakit/sample-forms/archive/master.zip)
Get the forms with my android device, fill some subs and send them
Pull the forms with Briefcase and check the files in my storage directory

I've also tried it in DigitalOcean using the latest aggregate-cli and emulating a release in my fork.

#### Why is this the best possible solution? Were any other approaches considered?
This is the simplest solution I can think of to conditionally avoid redirecting to the canonical hostname (either detected on startup or configured via security.properties file) when the HTTP request's hostname doesn't match it.

#### Are there any risks to merging this code? If so, what are they?
No.

The Aggregate-CLI needs to be updated with this
https://github.com/opendatakit/aggregate-cli/issues/7

#### Do we need any specific form for testing your changes? If so, please attach one
Any form will do, but I've linked the ones I've used above.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.