### PR TITLE
Fix sed error that breaks installs

### DIFF
--- a/cloud-config/assets/cloud-config.yml
+++ b/cloud-config/assets/cloud-config.yml
@@ -86,8 +86,8 @@ runcmd:
   - su postgres -c "psql -c \"CREATE SCHEMA aggregate\" aggregate"
   - su postgres -c "psql -c \"GRANT ALL PRIVILEGES ON SCHEMA aggregate TO aggregate\" aggregate"
 
-  - sed -i -e 's/foo\.bar/'"$(curl http://169.254.169.254/metadata/v1/hostname)"/' /root/aggregate-config.json
-  - sed -i -e 's/foo\.bar/'"$(curl http://169.254.169.254/metadata/v1/hostname)"/' /etc/nginx/sites-enabled/aggregate
+  - sed -i -e 's/foo\.bar/'"$(curl http://169.254.169.254/metadata/v1/hostname)"'/' /root/aggregate-config.json
+  - sed -i -e 's/foo\.bar/'"$(curl http://169.254.169.254/metadata/v1/hostname)"'/' /etc/nginx/sites-enabled/aggregate
 
   - aggregate-cli -i -y -c /root/aggregate-config.json
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Confirmed this works with clean install on DO. Also confirmed HTTPS certs are installed.

#### Why is this the best possible solution? Were any other approaches considered?
Narrowest fix possible. 

#### Are there any risks to merging this code? If so, what are they?
Yes. I am still getting infinite redirects even after using aggregate-cli to install a custom war. Not sure where the problem is, but my recommendation is that we get as close to a stock install as possible. So I'd recommend... 
1. Merge this change.
1. Publish master as a temporary v2.0.0 pre-release WAR on GitHub
1. Copy this PRs [cloud-config](https://raw.githubusercontent.com/opendatakit/aggregate/bf0d82d7fde05d4bc1417f1bf77a2958db29b901/cloud-config/assets/cloud-config.yml) into DO.
1. Edit the config so aggregate-cli gets pre-releases (add `-ip`)
1. Confirm that cloud-init-output is clean
1. Run certbot to get HTTPS working
1. Confirm if page loads with no redirects

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.