### PR TITLE
Issue 210 validate publisher form

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ war {
 
 gretty {
   contextPath = '/'
-  host = 'localhost'
+  host = '192.168.1.134'
   logDir = 'logs'
 }
 

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -249,7 +249,7 @@ public final class PublishPopup extends AbstractPopupBase {
 
           secureRequest(
               SecureGWT.getServicesAdminService(),
-              (rpc, sc, cb) -> rpc.createGoogleSpreadsheet(formId, workbookName, serviceOp, ownerEmail, cb),
+              (rpc, sc, cb) -> rpc.createGoogleSpreadsheet(formId, workbookName, serviceOp, "mailto:" + ownerEmail, cb),
               NO_OP_CONSUMER,
               this::onFailure
           );

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -204,12 +204,14 @@ public final class PublishPopup extends AbstractPopupBase {
     public void onClick(ClickEvent event) {
 
       String externalServiceTypeString = serviceType.getSelectedValue();
-      ExternalServiceType type = (externalServiceTypeString == null) ? null :
-          ExternalServiceType.valueOf(externalServiceTypeString);
+      ExternalServiceType type = (externalServiceTypeString == null)
+          ? null
+          : ExternalServiceType.valueOf(externalServiceTypeString);
 
       String serviceOpString = esOptions.getSelectedValue();
-      ExternalServicePublicationOption serviceOp = (serviceOpString == null) ? null :
-          ExternalServicePublicationOption.valueOf(serviceOpString);
+      ExternalServicePublicationOption serviceOp = (serviceOpString == null)
+          ? null
+          : ExternalServicePublicationOption.valueOf(serviceOpString);
 
       UserSecurityInfo info = AggregateUI.getUI().getUserInfo();
       String ownerEmail = getOwnerEmail(info);

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -31,14 +31,12 @@ import com.google.gwt.user.client.ui.TextBox;
 import java.util.function.Consumer;
 import org.opendatakit.aggregate.client.AggregateUI;
 import org.opendatakit.aggregate.client.SecureGWT;
-import org.opendatakit.aggregate.client.UIUtils;
 import org.opendatakit.aggregate.client.widgets.AggregateButton;
 import org.opendatakit.aggregate.client.widgets.ClosePopupButton;
 import org.opendatakit.aggregate.client.widgets.EnumListBox;
 import org.opendatakit.aggregate.constants.common.BinaryOption;
 import org.opendatakit.aggregate.constants.common.ExternalServicePublicationOption;
 import org.opendatakit.aggregate.constants.common.ExternalServiceType;
-import org.opendatakit.common.security.client.UserSecurityInfo;
 
 public final class PublishPopup extends AbstractPopupBase {
 
@@ -255,11 +253,18 @@ public final class PublishPopup extends AbstractPopupBase {
           );
           break;
         case JSON_SERVER: {
+          // Validate the URL to publish to
+          String url = jsUrl.getText();
+          if (url == null || url.isEmpty()) {
+            Window.alert("You must provide a URL to publish to");
+            return;
+          }
+
           final String jsBinaryOpString = jsBinaryOptions.getSelectedValue();
           final BinaryOption jsBinaryOp = (jsBinaryOpString == null) ? null : BinaryOption.valueOf(jsBinaryOpString);
           secureRequest(
               SecureGWT.getServicesAdminService(),
-              (rpc, sc, cb) -> rpc.createSimpleJsonServer(formId, jsAuthKey.getText(), jsUrl.getText(), serviceOp, "mailto:N/A", jsBinaryOp, cb),
+              (rpc, sc, cb) -> rpc.createSimpleJsonServer(formId, jsAuthKey.getText(), url, serviceOp, "mailto:N/A", jsBinaryOp, cb),
               NO_OP_CONSUMER,
               this::onFailure
           );

--- a/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
+++ b/src/main/java/org/opendatakit/aggregate/client/popups/PublishPopup.java
@@ -213,13 +213,13 @@ public final class PublishPopup extends AbstractPopupBase {
           ? null
           : ExternalServicePublicationOption.valueOf(serviceOpString);
 
-      UserSecurityInfo info = AggregateUI.getUI().getUserInfo();
-      String ownerEmail = getOwnerEmail(info);
-      if (ownerEmail == null)
-        return;
-
       switch (type) {
         case GOOGLE_SPREADSHEET:
+          UserSecurityInfo info = AggregateUI.getUI().getUserInfo();
+          String ownerEmail = getOwnerEmail(info);
+          if (ownerEmail == null)
+            return;
+
           secureRequest(
               SecureGWT.getServicesAdminService(),
               (rpc, sc, cb) -> rpc.createGoogleSpreadsheet(formId, gsName.getText(), serviceOp, ownerEmail, cb),
@@ -232,7 +232,7 @@ public final class PublishPopup extends AbstractPopupBase {
           final BinaryOption jsBinaryOp = (jsBinaryOpString == null) ? null : BinaryOption.valueOf(jsBinaryOpString);
           secureRequest(
               SecureGWT.getServicesAdminService(),
-              (rpc, sc, cb) -> rpc.createSimpleJsonServer(formId, jsAuthKey.getText(), jsUrl.getText(), serviceOp, ownerEmail, jsBinaryOp, cb),
+              (rpc, sc, cb) -> rpc.createSimpleJsonServer(formId, jsAuthKey.getText(), jsUrl.getText(), serviceOp, "mailto:N/A", jsBinaryOp, cb),
               NO_OP_CONSUMER,
               this::onFailure
           );


### PR DESCRIPTION
Closes #208, #209, #210

#### What has been done to verify that this works as intended?
Manually tried all field combinations in both publishers in the dev server.

#### Why is this the best possible solution? Were any other approaches considered?
No other approaches were considered. It's the narrowest change I could come up with that provides basic form validation.

An alternative would be to disable the button if the form is not valid. I don't have a strong opinion about this approach.

#### Are there any risks to merging this code? If so, what are they?

Common publisher form changes:
- Alerts will be shown when no type of publisher or kind of upload (all, new, existing) is selected
  There is really no way to test this without tampering with the form, although validating forms is always a good idea. These validations will be handy in case we change the form and we open the option of not selecting an option on those selects.

Changes to the Google Spreasheet publisher form:
- Users should expect a new publisher form that includes the owner's email:
  ![image](https://user-images.githubusercontent.com/205913/52634636-01cc1680-2ec8-11e9-90d8-87996e32f66f.png)
- Alerts will be shown if the user doesn't provide a workbook name or a valid owner's email address.

Changes to the JSON publisher form:
- It won't ask for the owner's email, since it's not really required to create it.
- In the publishers table, we use "N/A" in the "owner" column for JSON publishers.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.