### PR TITLE
Issue 409 remove Location header from 204 HTTP responses

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/servlet/FormUploadServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/FormUploadServlet.java
@@ -188,14 +188,8 @@ public class FormUploadServlet extends ServletUtilBase {
    */
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) {
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
-    logger.info("Inside doHead");
-
     addOpenRosaHeaders(resp);
-    String serverUrl = cc.getServerURL();
-    String url = serverUrl + BasicConsts.FORWARDSLASH + ADDR;
-    resp.setHeader("Location", url);
-    resp.setStatus(204); // no content...
+    resp.setStatus(204);
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/servlet/ResetUsersAndPermissionsServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ResetUsersAndPermissionsServlet.java
@@ -47,7 +47,6 @@ import org.opendatakit.common.security.common.EmailParser.Email.Form;
 import org.opendatakit.common.security.common.GrantedAuthorityName;
 import org.opendatakit.common.security.server.SecurityServiceUtil;
 import org.opendatakit.common.web.CallingContext;
-import org.opendatakit.common.web.constants.BasicConsts;
 import org.opendatakit.common.web.constants.HtmlConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,14 +178,8 @@ public class ResetUsersAndPermissionsServlet extends ServletUtilBase {
    */
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) {
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
-    logger.info("Inside doHead");
-
     addOpenRosaHeaders(resp);
-    String serverUrl = cc.getServerURL();
-    String url = serverUrl + BasicConsts.FORWARDSLASH + ADDR;
-    resp.setHeader("Location", url);
-    resp.setStatus(204); // no content...
+    resp.setStatus(204);
   }
 
   /**

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionServlet.java
@@ -189,14 +189,8 @@ public class SubmissionServlet extends ServletUtilBase {
    */
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) {
-    CallingContext cc = ContextFactory.getCallingContext(this, req);
-    logger.info("Inside doHead");
-
     addOpenRosaHeaders(resp);
-    String serverUrl = cc.getServerURL();
-    String url = serverUrl + BasicConsts.FORWARDSLASH + ADDR;
-    resp.setHeader("Location", url);
-    resp.setStatus(204); // no content...
+    resp.setStatus(204);
   }
 
   /**


### PR DESCRIPTION
Closes #409

#### What has been done to verify that this works as intended?
Verify in Aggregate:
- Uploading forms works
- Manually uploading a submission works
- Changing user password and granted permissions works

Verify using Briefcase:
- Pushing a form with submissions works

#### Why is this the best possible solution? Were any other approaches considered?
HTTP 204 responses should not have a `Location` header. 

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.