### PR TITLE
Revert to previous code that had the webapp's path into account

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/servlet/ClearSessionThenLoginServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ClearSessionThenLoginServlet.java
@@ -63,11 +63,11 @@ public class ClearSessionThenLoginServlet extends ServletUtilBase {
     String newUrl;
     if (isAnon) {
       // anonymous user -- go to the login page...
-      newUrl = "/multimode_login.html";
+      newUrl = cc.getWebApplicationURL("multimode_login.html");
     } else {
       // we are logged in via token-based or basic or digest auth.
       // redirect to Spring's logout url...
-      newUrl = "/" + cc.getUserService().createLogoutURL();
+      newUrl = cc.getWebApplicationURL("/" + cc.getUserService().createLogoutURL());
     }
     // preserve the query string (helps with GWT debugging)
     String query = req.getQueryString();


### PR DESCRIPTION
Closes #419 

#### What has been done to verify that this works as intended?
Run Aggregate in a local Tomcat both as ROOT and non-ROOT webapp, having configured a hostname and disabled the hostnames check.

In master, the login of the non-ROOT webapp won't work, and this PR solves that.

Also tested that this PR doesn't break the Cloud-Config stack by running it locally and verifying that the login still works.

#### Why is this the best possible solution? Were any other approaches considered?
This PR solves a regression bug introduced in v2.0.0. The change is to restore the original redirection code.

#### Are there any risks to merging this code? If so, what are they?
Nope.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.