### PR TITLE
Issue 420 fix installer conf file assets

### DIFF
--- a/installer/project/components/configure_war.xml
+++ b/installer/project/components/configure_war.xml
@@ -254,6 +254,11 @@
         </actionGroup>
         <propertiesFileSet>
           <file>${temp_dir}/conf/common/security.properties</file>
+          <key>security.server.forceHttpsLinks</key>
+          <value>false</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/common/security.properties</file>
           <key>security.server.port</key>
           <value>${http_port}</value>
         </propertiesFileSet>
@@ -269,11 +274,6 @@
         </propertiesFileSet>
         <propertiesFileSet>
           <file>${temp_dir}/conf/common/security.properties</file>
-          <key>security.server.superUser</key>
-          <value></value>
-        </propertiesFileSet>
-        <propertiesFileSet>
-          <file>${temp_dir}/conf/common/security.properties</file>
           <key>security.server.superUserUsername</key>
           <value>${username}</value>
         </propertiesFileSet>
@@ -284,9 +284,8 @@
         </propertiesFileSet>
         <propertiesFileSet>
           <file>${temp_dir}/conf/common/security.properties</file>
-          <key>security.help.about</key>
-          <value>
-            <![CDATA[auto-generated on ${creation.timestamp} for ${instance_display_name} ${product_fullname} ${product_version}]]></value>
+          <key>security.server.checkHostnames</key>
+          <value>true</value>
         </propertiesFileSet>
       </actionList>
     </actionGroup>

--- a/installer/project/components/configure_war.xml
+++ b/installer/project/components/configure_war.xml
@@ -101,67 +101,121 @@
       <actionList>
         <propertiesFileSet>
           <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
-          <key>jdbc.help.about</key>
-          <value>Generated on ${creation.timestamp} for ${instance_display_name} ${product_fullname} ${product_version}</value>
+          <key>installer</key>
+          <value>Dummy key created by the installer</value>
         </propertiesFileSet>
       </actionList>
     </actionGroup>
     <actionGroup>
-      <!-- Sets the JDBC properties in jdbc.properties for MySQL and PostgreSQL -->
-      <explanation>Set jdbc properties</explanation>
-      <progressText>Setting jdbc properties</progressText>
+      <!-- Set PostgreSQL JDBC configuration -->
+      <explanation>Set PostgreSQL jdbc properties</explanation>
+      <progressText>Setting PostgreSQL jdbc properties</progressText>
       <actionList>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
-          <key>jdbc.url</key>
-          <value>jdbc:${platform}://${database_host_port}/${jdbc_database}?autoDeserialize=true</value>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
+          <key>jdbc.driverClassName</key>
+          <value>org.postgresql.Driver</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
+          <key>jdbc.resourceName</key>
+          <value>jdbc/aggregate</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
+          <key>jdbc.url</key>
+          <value>jdbc:postgresql://${database_host_port}/${jdbc_database}?autoDeserialize=true</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
           <key>jdbc.username</key>
           <value>${jdbc_username}</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
           <key>jdbc.password</key>
           <value>${jdbc_password}</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
           <key>jdbc.schema</key>
           <value>${jdbc_schema}</value>
         </propertiesFileSet>
       </actionList>
       <ruleList>
-        <ruleGroup>
-          <ruleEvaluationLogic>or</ruleEvaluationLogic>
-          <ruleList>
-            <compareText>
-              <logic>equals</logic>
-              <text>${platform}</text>
-              <value>mysql</value>
-            </compareText>
-            <compareText>
-              <logic>equals</logic>
-              <text>${platform}</text>
-              <value>postgresql</value>
-            </compareText>
-          </ruleList>
-        </ruleGroup>
+        <compareText>
+          <logic>equals</logic>
+          <text>${platform}</text>
+          <value>postgresql</value>
+        </compareText>
       </ruleList>
     </actionGroup>
     <actionGroup>
-      <!-- Sets the JDBC properties in jdbc.properties for SQLServer -->
+      <!-- Set MySQL JDBC configuration -->
       <explanation>Set jdbc properties</explanation>
       <progressText>Setting jdbc properties</progressText>
       <actionList>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.driverClassName</key>
+          <value>com.mysql.jdbc.Driver</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.resourceName</key>
+          <value>jdbc/aggregate</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.url</key>
+          <value>jdbc:mysql://${database_host_port}/${jdbc_database}?autoDeserialize=true</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.username</key>
+          <value>${jdbc_username}</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.password</key>
+          <value>${jdbc_password}</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.schema</key>
+          <value>${jdbc_schema}</value>
+        </propertiesFileSet>
+      </actionList>
+      <ruleList>
+        <compareText>
+          <logic>equals</logic>
+          <text>${platform}</text>
+          <value>mysql</value>
+        </compareText>
+      </ruleList>
+    </actionGroup>
+    <actionGroup>
+      <!-- Set SQLServer JDBC configuration -->
+      <explanation>Set jdbc properties</explanation>
+      <progressText>Setting jdbc properties</progressText>
+      <actionList>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
+          <key>jdbc.driverClassName</key>
+          <value>com.microsoft.sqlserver.jdbc.SQLServerDriver</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
+          <key>jdbc.resourceName</key>
+          <value>jdbc/aggregate</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
           <key>jdbc.url</key>
           <value>${jdbc_url}</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
           <key>jdbc.schema</key>
           <value>${jdbc_schema}</value>
         </propertiesFileSet>

--- a/installer/project/components/params.xml
+++ b/installer/project/components/params.xml
@@ -554,7 +554,7 @@ The installer will generate a script that can be run on the database server to e
           <description>Database username:</description>
           <explanation></explanation>
           <value></value>
-          <default>odk_user</default>
+          <default>aggregate</default>
           <allowEmptyValue>0</allowEmptyValue>
           <width>30</width>
         </stringParameter>
@@ -602,7 +602,7 @@ The installer will generate a script that can be run on the database server to c
           <description>Database Name:</description>
           <explanation></explanation>
           <value></value>
-          <default>odk_prod</default>
+          <default>aggregate</default>
           <allowEmptyValue>0</allowEmptyValue>
           <width>30</width>
         </stringParameter>
@@ -611,7 +611,7 @@ The installer will generate a script that can be run on the database server to c
           <description>Database Schema Name:</description>
           <explanation></explanation>
           <value></value>
-          <default>odk_prod</default>
+          <default>aggregate</default>
           <allowEmptyValue>0</allowEmptyValue>
           <width>30</width>
           <ruleList>
@@ -656,7 +656,7 @@ The Windows user or group will be granted the permissions to manage and write in
           <description>Database Name:</description>
           <explanation></explanation>
           <value></value>
-          <default>odk_prod</default>
+          <default>aggregate</default>
           <allowEmptyValue>0</allowEmptyValue>
           <width>30</width>
         </stringParameter>
@@ -665,7 +665,7 @@ The Windows user or group will be granted the permissions to manage and write in
           <description>Database Schema Name:</description>
           <explanation></explanation>
           <value></value>
-          <default>odk_prod</default>
+          <default>aggregate</default>
           <allowEmptyValue>0</allowEmptyValue>
           <width>30</width>
         </stringParameter>
@@ -675,7 +675,7 @@ The Windows user or group will be granted the permissions to manage and write in
           <explanation>
             <![CDATA[Enter the Domain\Username or group that the Tomcat 8 server will run as and use to access the database.]]></explanation>
           <value></value>
-          <default>odk_prod</default>
+          <default>aggregate</default>
           <allowEmptyValue>0</allowEmptyValue>
           <width>30</width>
         </stringParameter>

--- a/installer/project/files/conf/mysql/odk-settings.xml
+++ b/installer/project/files/conf/mysql/odk-settings.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:task="http://www.springframework.org/schema/task"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/task
            http://www.springframework.org/schema/task/spring-task-4.1.xsd">
 
-  <bean
-      class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
     <property name="locations">
       <list>
         <value>classpath:jdbc.properties</value>
@@ -34,10 +33,8 @@
     <property name="testOnBorrow" value="true"/>
   </bean>
 
-  <bean id="datastore"
-        class="org.opendatakit.common.persistence.engine.mysql.DatastoreImpl">
+  <bean id="datastore" class="org.opendatakit.common.persistence.engine.mysql.DatastoreImpl">
     <property name="dataSource" ref="dataSource"/>
-    <!--		schemaName defaults to the database name.  Override this with: -->
     <property name="schemaName" value="${jdbc.schema}"/>
   </bean>
 
@@ -57,7 +54,7 @@
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">
     <property name="datastore" ref="datastore"/>
     <property name="realm" ref="realm"/>
-    <property name="superUserEmail" value="${security.server.superUser}"/>
+    <property name="superUserEmail" value=""/>
     <property name="superUserUsername" value="${security.server.superUserUsername}"/>
   </bean>
 
@@ -70,12 +67,10 @@
   <!--  change the background scheduler to only have three worker threads. Tasks will be queued. -->
   <task:scheduler id="task_scheduler" pool-size="3"/>
 
-  <bean id="worksheet_creator"
-        class="org.opendatakit.aggregate.task.WorksheetCreator"/>
+  <bean id="worksheet_creator" class="org.opendatakit.aggregate.task.WorksheetCreator"/>
   <bean id="form_delete" class="org.opendatakit.aggregate.task.FormDelete"/>
   <bean id="purge_submissions" class="org.opendatakit.aggregate.task.PurgeOlderSubmissions"/>
-  <bean id="upload_task"
-        class="org.opendatakit.aggregate.task.UploadSubmissions"/>
+  <bean id="upload_task" class="org.opendatakit.aggregate.task.UploadSubmissions"/>
   <bean id="kml_task" class="org.opendatakit.aggregate.task.KmlGenerator"/>
   <bean id="csv_task" class="org.opendatakit.aggregate.task.CsvGenerator"/>
   <bean id="json_file_task" class="org.opendatakit.aggregate.task.JsonFileGenerator"/>

--- a/installer/project/files/conf/postgresql/odk-settings.xml
+++ b/installer/project/files/conf/postgresql/odk-settings.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:task="http://www.springframework.org/schema/task"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/task
            http://www.springframework.org/schema/task/spring-task-4.1.xsd">
 
-  <bean
-      class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
     <property name="locations">
       <list>
         <value>classpath:jdbc.properties</value>
@@ -34,10 +33,8 @@
     <property name="testOnBorrow" value="true"/>
   </bean>
 
-  <bean id="datastore"
-        class="org.opendatakit.common.persistence.engine.pgres.DatastoreImpl">
+  <bean id="datastore" class="org.opendatakit.common.persistence.engine.pgres.DatastoreImpl">
     <property name="dataSource" ref="dataSource"/>
-    <!--		schemaName defaults to the database name.  Override this with: -->
     <property name="schemaName" value="${jdbc.schema}"/>
   </bean>
 
@@ -57,7 +54,7 @@
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">
     <property name="datastore" ref="datastore"/>
     <property name="realm" ref="realm"/>
-    <property name="superUserEmail" value="${security.server.superUser}"/>
+    <property name="superUserEmail" value=""/>
     <property name="superUserUsername" value="${security.server.superUserUsername}"/>
   </bean>
 
@@ -70,12 +67,10 @@
   <!--  change the background scheduler to only have three worker threads. Tasks will be queued. -->
   <task:scheduler id="task_scheduler" pool-size="3"/>
 
-  <bean id="worksheet_creator"
-        class="org.opendatakit.aggregate.task.WorksheetCreator"/>
+  <bean id="worksheet_creator" class="org.opendatakit.aggregate.task.WorksheetCreator"/>
   <bean id="form_delete" class="org.opendatakit.aggregate.task.FormDelete"/>
   <bean id="purge_submissions" class="org.opendatakit.aggregate.task.PurgeOlderSubmissions"/>
-  <bean id="upload_task"
-        class="org.opendatakit.aggregate.task.UploadSubmissions"/>
+  <bean id="upload_task" class="org.opendatakit.aggregate.task.UploadSubmissions"/>
   <bean id="kml_task" class="org.opendatakit.aggregate.task.KmlGenerator"/>
   <bean id="csv_task" class="org.opendatakit.aggregate.task.CsvGenerator"/>
   <bean id="json_file_task" class="org.opendatakit.aggregate.task.JsonFileGenerator"/>

--- a/installer/project/files/conf/sqlserver/odk-settings.xml
+++ b/installer/project/files/conf/sqlserver/odk-settings.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:task="http://www.springframework.org/schema/task"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/task
            http://www.springframework.org/schema/task/spring-task-4.1.xsd">
 
-  <bean
-      class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
     <property name="locations">
       <list>
         <value>classpath:jdbc.properties</value>
@@ -35,10 +34,8 @@
     <property name="testOnReturn" value="true"/>
   </bean>
 
-  <bean id="datastore"
-        class="org.opendatakit.common.persistence.engine.sqlserver.DatastoreImpl">
+  <bean id="datastore" class="org.opendatakit.common.persistence.engine.sqlserver.DatastoreImpl">
     <property name="dataSource" ref="dataSource"/>
-    <!--		schemaName defaults to the database name.  Override this with: -->
     <property name="schemaName" value="${jdbc.schema}"/>
   </bean>
 
@@ -58,7 +55,7 @@
   <bean id="user_service" class="org.opendatakit.common.security.spring.UserServiceImpl">
     <property name="datastore" ref="datastore"/>
     <property name="realm" ref="realm"/>
-    <property name="superUserEmail" value="${security.server.superUser}"/>
+    <property name="superUserEmail" value=""/>
     <property name="superUserUsername" value="${security.server.superUserUsername}"/>
   </bean>
 
@@ -71,12 +68,10 @@
   <!--  change the background scheduler to only have three worker threads. Tasks will be queued. -->
   <task:scheduler id="task_scheduler" pool-size="3"/>
 
-  <bean id="worksheet_creator"
-        class="org.opendatakit.aggregate.task.WorksheetCreator"/>
+  <bean id="worksheet_creator" class="org.opendatakit.aggregate.task.WorksheetCreator"/>
   <bean id="form_delete" class="org.opendatakit.aggregate.task.FormDelete"/>
   <bean id="purge_submissions" class="org.opendatakit.aggregate.task.PurgeOlderSubmissions"/>
-  <bean id="upload_task"
-        class="org.opendatakit.aggregate.task.UploadSubmissions"/>
+  <bean id="upload_task" class="org.opendatakit.aggregate.task.UploadSubmissions"/>
   <bean id="kml_task" class="org.opendatakit.aggregate.task.KmlGenerator"/>
   <bean id="csv_task" class="org.opendatakit.aggregate.task.CsvGenerator"/>
   <bean id="json_file_task" class="org.opendatakit.aggregate.task.JsonFileGenerator"/>


### PR DESCRIPTION
Closes #420, and #429

#### What has been done to verify that this works as intended?
Build the installer, check the files it deploys, and deploy in local tomcat

Build the installer (linux-x64) and run it, then deploy the resulting WAR into a local Tomcat. Verify that Aggregate launches without changing anything.

#### Why is this the best possible solution? Were any other approaches considered?
The changes are conforming to any other task in the installer (set values in conf files, etc.)

This PR adds some required adaptations from v1.x to v2.x into the installer

In v1.x, the `odk-settings.xml` for each platform comes with a hard-coded driver classname, which deviates from the same file in the code repo, which uses whatever value is defined in the jdbc.driverClassName` props key in `jdbc.properties`

In v2.x, we have made an effort to normalize all the different configuration assets, and we changed the `odk-settings.xml` that the installer uses, but forgot to set the prop key in the jdbc settings file.

This PR takes care of that.

#### Are there any risks to merging this code? If so, what are they?
Nope, although we should test 

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.