### PR TITLE
Issue 429 Fix the JDBC conf file the installer creates

### DIFF
--- a/installer/project/components/configure_war.xml
+++ b/installer/project/components/configure_war.xml
@@ -101,67 +101,121 @@
       <actionList>
         <propertiesFileSet>
           <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
-          <key>jdbc.help.about</key>
-          <value>Generated on ${creation.timestamp} for ${instance_display_name} ${product_fullname} ${product_version}</value>
+          <key>installer</key>
+          <value>Dummy key created by the installer</value>
         </propertiesFileSet>
       </actionList>
     </actionGroup>
     <actionGroup>
-      <!-- Sets the JDBC properties in jdbc.properties for MySQL and PostgreSQL -->
-      <explanation>Set jdbc properties</explanation>
-      <progressText>Setting jdbc properties</progressText>
+      <!-- Set PostgreSQL JDBC configuration -->
+      <explanation>Set PostgreSQL jdbc properties</explanation>
+      <progressText>Setting PostgreSQL jdbc properties</progressText>
       <actionList>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
-          <key>jdbc.url</key>
-          <value>jdbc:${platform}://${database_host_port}/${jdbc_database}?autoDeserialize=true</value>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
+          <key>jdbc.driverClassName</key>
+          <value>org.postgresql.Driver</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
+          <key>jdbc.resourceName</key>
+          <value>jdbc/aggregate</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
+          <key>jdbc.url</key>
+          <value>jdbc:postgresql://${database_host_port}/${jdbc_database}?autoDeserialize=true</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
           <key>jdbc.username</key>
           <value>${jdbc_username}</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
           <key>jdbc.password</key>
           <value>${jdbc_password}</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/postgresql/jdbc.properties</file>
           <key>jdbc.schema</key>
           <value>${jdbc_schema}</value>
         </propertiesFileSet>
       </actionList>
       <ruleList>
-        <ruleGroup>
-          <ruleEvaluationLogic>or</ruleEvaluationLogic>
-          <ruleList>
-            <compareText>
-              <logic>equals</logic>
-              <text>${platform}</text>
-              <value>mysql</value>
-            </compareText>
-            <compareText>
-              <logic>equals</logic>
-              <text>${platform}</text>
-              <value>postgresql</value>
-            </compareText>
-          </ruleList>
-        </ruleGroup>
+        <compareText>
+          <logic>equals</logic>
+          <text>${platform}</text>
+          <value>postgresql</value>
+        </compareText>
       </ruleList>
     </actionGroup>
     <actionGroup>
-      <!-- Sets the JDBC properties in jdbc.properties for SQLServer -->
+      <!-- Set MySQL JDBC configuration -->
       <explanation>Set jdbc properties</explanation>
       <progressText>Setting jdbc properties</progressText>
       <actionList>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.driverClassName</key>
+          <value>com.mysql.jdbc.Driver</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.resourceName</key>
+          <value>jdbc/aggregate</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.url</key>
+          <value>jdbc:mysql://${database_host_port}/${jdbc_database}?autoDeserialize=true</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.username</key>
+          <value>${jdbc_username}</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.password</key>
+          <value>${jdbc_password}</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/mysql/jdbc.properties</file>
+          <key>jdbc.schema</key>
+          <value>${jdbc_schema}</value>
+        </propertiesFileSet>
+      </actionList>
+      <ruleList>
+        <compareText>
+          <logic>equals</logic>
+          <text>${platform}</text>
+          <value>mysql</value>
+        </compareText>
+      </ruleList>
+    </actionGroup>
+    <actionGroup>
+      <!-- Set SQLServer JDBC configuration -->
+      <explanation>Set jdbc properties</explanation>
+      <progressText>Setting jdbc properties</progressText>
+      <actionList>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
+          <key>jdbc.driverClassName</key>
+          <value>com.microsoft.sqlserver.jdbc.SQLServerDriver</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
+          <key>jdbc.resourceName</key>
+          <value>jdbc/aggregate</value>
+        </propertiesFileSet>
+        <propertiesFileSet>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
           <key>jdbc.url</key>
           <value>${jdbc_url}</value>
         </propertiesFileSet>
         <propertiesFileSet>
-          <file>${temp_dir}/conf/${platform}/jdbc.properties</file>
+          <file>${temp_dir}/conf/sqlserver/jdbc.properties</file>
           <key>jdbc.schema</key>
           <value>${jdbc_schema}</value>
         </propertiesFileSet>


### PR DESCRIPTION
Closes #429

This PR brings changes to the installer that ensure that all the jdbc properties are set by the installer.

#### What has been done to verify that this works as intended?
Build the installer (linux-x64) and run it, then deploy the resulting WAR into a local Tomcat. Verify that Aggregate launches without changing anything.

#### Why is this the best possible solution? Were any other approaches considered?
This PR adds some required adaptations from v1.x to v2.x into the installer

In v1.x, the `odk-settings.xml` for each platform comes with a hard-coded driver classname, which deviates from the same file in the code repo, which uses whatever value is defined in the jdbc.driverClassName` props key in `jdbc.properties`

In v2.x, we have made an effort to normalize all the different configuration assets, and we changed the `odk-settings.xml` that the installer uses, but forgot to set the prop key in the jdbc settings file.

This PR takes care of that.

#### Are there any risks to merging this code? If so, what are they?
Nope. It only affects to the installer.

#### Do we need any specific form for testing your changes? If so, please attach one
Nope.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
Nope.