### PR TITLE
Allow mounting configuration files via Docker Volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Aggregate supports a variety of database engines, but we strongly recommend Post
 
 3. Stop the server with `./gradlew postgresqlComposeDown`
 
-For more information see [here for Docker](docs/build-and-run-a-docker-image.md) and [here for Docker Compose]((docs/build-and-run-with-docker-compose.md)).
+For more information see [here for Docker](docs/build-and-run-a-docker-image.md) and [here for Docker Compose]((docs/build-and-run-with-docker-compose.md).
 
 ### Local PostgreSQL server
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ODK Aggregate can be deployed on an Apache Tomcat server, or any servlet 2.5-com
 ## Setting up the database
 
 Aggregate supports a variety of database engines, but we strongly recommend PostgreSQL. If you wish to use MySQL, see the [database configurations](docs/database-configurations.md) guide.
- 
+
 ### PostgreSQL with Docker
 
 1. Install [Docker](https://www.docker.com) and [Docker Compose](https://docs.docker.com/compose)
@@ -42,6 +42,8 @@ Aggregate supports a variety of database engines, but we strongly recommend Post
     Check that the port number **5432** is not used by any other service in your computer. You can change this editing the `ports` section of the `db/postgresql/docker-compose.yml` configuration file. Be sure to check the documentation: [Compose file version 3 reference - Ports section](https://docs.docker.com/compose/compose-file/#ports).
 
 3. Stop the server with `./gradlew postgresqlComposeDown`
+
+For more information see [here for Docker](docs/build-and-run-a-docker-image.md) and [here for Docker Compose]((docs/build-and-run-with-docker-compose.md)).
 
 ### Local PostgreSQL server
 
@@ -76,7 +78,9 @@ Aggregate supports a variety of database engines, but we strongly recommend Post
 
 - Copy the `jdbc.properties.example`, `odk-settings.xml.example`, and `security.properties.example` files at `/src/main/resources` to the same location, removing the `.example` extension.
 
-  If you have followed the database configuration steps above, you don't need to make any change in these files. Otherwise, head to the [Aggregate configuration guide](docs/aggregate-config.md) and make the required changes for your environment. Note that if you are running in Docker this step is not necessary as the build scripts copy those files for you and automatically override any values set in those files. See [here](docs/build-and-run-a-docker-image.md).
+  If you have followed the database configuration steps above, you don't need to make any change in these files. Otherwise, head to the [Aggregate configuration guide](docs/aggregate-config.md) and make the required changes for your environment. 
+
+  If you are running the project in Docker, see [here](docs/build-and-run-a-docker-image.md) for the next steps.
   
 - Start a local development Aggregate server with `./gradlew appRunWar`
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -65,7 +65,7 @@ echo
 echo
 echo "${AGGREGATE_CONF_DIR}/jdbc.properties:"
 echo "-----"
-cat ${JDBC_PROPS} # todo hide the password
+cat ${JDBC_PROPS} | sed -E -e "s/^jdbc\.password=.*$/jdbc.password=<hidden>/g"
 echo
 echo "${AGGREGATE_CONF_DIR}/security.properties:"
 echo "-----"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,27 +8,27 @@ TOMCAT_CONF=/usr/local/tomcat/conf/server.xml
 
 if [ -f "/etc/config/server.xml" ]; then 
   rm  ${TOMCAT_CONF}
-  ln -s /etc/config/server.xml ${TOMCAT_CONF}
+  cp /etc/config/server.xml ${TOMCAT_CONF}
 fi
 
 if [ -f "/etc/config/odk-settings.xml" ]; then 
   rm  ${ODK_SETTINGS}
-  ln -s /etc/config/odk-settings.xml ${ODK_SETTINGS}
+  cp /etc/config/odk-settings.xml ${ODK_SETTINGS}
 fi
 
 if [ -f "/etc/config/security.properties" ]; then 
   rm  ${SECURITY_PROPS}
-  ln -s /etc/config/security.properties ${SECURITY_PROPS}
+  cp /etc/config/security.properties ${SECURITY_PROPS}
 fi
 
 if [ -f "/etc/config/jdbc.properties" ]; then 
   rm  ${JDBC_PROPS}
-  ln -s /etc/config/jdbc.properties ${JDBC_PROPS}
+  cp /etc/config/jdbc.properties ${JDBC_PROPS}
 fi
 
 if [ -f "/etc/config/security.properties" ]; then 
   rm  ${SECURITY_PROPS}
-  ln -s /etc/config/security.properties ${SECURITY_PROPS}
+  cp /etc/config/security.properties ${SECURITY_PROPS}
 fi
 
 replace() {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -82,6 +82,4 @@ echo
 echo
 echo
 
-exit 0
-
 catalina.sh run

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,9 +1,25 @@
 #!/usr/bin/env bash
 
 AGGREGATE_CONF_DIR=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes
+ODK_SETTINGS=${AGGREGATE_CONF_DIR}/odk-settings.xml
 SECURITY_PROPS=${AGGREGATE_CONF_DIR}/security.properties
 JDBC_PROPS=${AGGREGATE_CONF_DIR}/jdbc.properties
 TOMCAT_CONF=/usr/local/tomcat/conf/server.xml
+
+if [ -f "/etc/config/server.xml" ]; then 
+  rm  ${TOMCAT_CONF}
+  ln -s /etc/config/server.xml ${TOMCAT_CONF}
+fi
+
+if [ -f "/etc/config/odk-settings.xml" ]; then 
+  rm  ${ODK_SETTINGS}
+  ln -s /etc/config/odk-settings.xml ${ODK_SETTINGS}
+fi
+
+if [ -f "/etc/config/security.properties" ]; then 
+  rm  ${SECURITY_PROPS}
+  ln -s /etc/config/security.properties ${SECURITY_PROPS}
+fi
 
 if [ -f "/etc/config/jdbc.properties" ]; then 
   rm  ${JDBC_PROPS}

--- a/docs/build-and-run-a-docker-image.md
+++ b/docs/build-and-run-a-docker-image.md
@@ -65,19 +65,23 @@ This Aggregate Docker image works by using an external running PostgreSQL 9.6 da
 
 - The base of this Docker image is [tomcat:8.0-jre8-alpine](https://github.com/docker-library/repo-info/blob/master/repos/tomcat/remote/8.0-jre8-alpine.md)
 
-## Configuration parameters
 
-You can set the following environment variables when running the Aggregate Docker image:
+## Configuration
+
+You have two options for passing configuration to ODK. 
+
+### Environmental Variables
+If you are using PostgreSQL (recommended), you can set the following environment variables when running the Aggregate Docker image:
 
 | variable | Default value | Description |
 | --- | --- | --- |
 | AGGREGATE_HOST | localhost | Value of the `security.server.hostname` conf parameter. Set to `auto` for FQDN auto-discovery |
-| DB_HOST | localhost | Value used to build the `jdbc.url` conf parameter |
-| DB_PORT | 5432 | Value used to build the `jdbc.url` conf parameter |
-| DB_NAME | aggregate | Value used to build the `jdbc.url` conf parameter |
 | DB_SCHEMA | aggregate | Value of the `jdbc.schema` conf parameter |
 | DB_USERNAME | aggregate | Value of the `jdbc.username` conf parameter |
 | DB_PASSWORD | aggregate | Value of the `jdbc.password` conf parameter |
+| DB_HOST | localhost | Value used to build the `jdbc.url` conf parameter |
+| DB_PORT | 5432 | Value used to build the `jdbc.url` conf parameter |
+| DB_NAME | aggregate | Value used to build the `jdbc.url` conf parameter |
 
   These variables can be set by adding `--env VARIABLE_NAME=VALUE` arguments when running the Aggregate Docker image ([more info in the docs](https://docs.docker.com/docker-cloud/getting-started/deploy-app/6_define_environment_variables/#python-quickstart)). Example:
   
@@ -90,3 +94,22 @@ You can set the following environment variables when running the Aggregate Docke
 - All these conf parameters are explained in the [ODK Aggregate - Configuration files](./aggregate-config.md) document
 - If you are running your PostgreSQL server in the same host where you want to run the Aggregate Docker image you will probably need to add the `--network=host` argument when running it to allow the container access the host's services.
 - If you need to serve Aggregate in a different host port, use Docker's networking configuration options to redirect the guest's 8080 port to any other host port ([more info in the docs](https://docs.docker.com/config/containers/container-networking/))
+- If you are using a database engine other than PostgreSQL, you will need to follow the bind-mount technique outlined below.
+
+## Config Files
+
+For complete control of all of Aggregate's configuration values, you can also pass a copy of the `security.properties` and `jdbc.properties` files to Docker via a bind mount into the `/etc/config` directory in the Docker image. 
+
+Follow the directions in the main `README` regarding copying the `/src/main/resources/jdbc.properties.example`, `odk-settings.xml.example` and `security.properties` files, and pass them to Docker kind of like so:
+
+```shell 
+docker run -d -p 8080:8080 -it \
+--mount type=bind,source="$(pwd)"/src/main/resources/odk-settings.xml,target=/etc/config/odk-settings.xml,readonly \
+--mount type=bind,source="$(pwd)"/src/main/resources/jdbc.properties,target=/etc/config/jdbc.properties,readonly \
+--mount type=bind,source="$(pwd)"/src/main/resources/security.properties,target=/etc/config/security.properties,readonly \
+--name=aggregate aggregate:latest
+```
+
+Of course, you can place these files anywhere on your server that you wish, as long as you update the "source" directory above. You can also use this technique along with any Docker orchestration tool that supports mounting configuration values into files on the filesystem, [such as Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#populate-a-volume-with-data-stored-in-a-configmap). Just make sure the files are always mounted into `/etc/config`, as the `docker-entrypoint.sh` script makes symlinks from those directories into proper directory for Aggregate. You can also pass a custom Tomcat `server.xml`, though you shouldn't need to do this. 
+
+You can also continue to use the environmental variables technique above to override any values set in the files.

--- a/docs/build-and-run-a-docker-image.md
+++ b/docs/build-and-run-a-docker-image.md
@@ -9,10 +9,10 @@
   - Only then clone your fork of Aggregate - included .jar files only download correctly with Git LFS. See [Getting the code](https://github.com/opendatakit/aggregate#getting-the-code).
   - Install IntelliJ IDEA and import project as instructed to let IDEA download, build, and configure sources. See [Running the project - Import](https://github.com/opendatakit/aggregate#import)
 
-  *Note*: this is a gentle reminder to follow the main [README](https://github.com/opendatakit/aggregate), not a comprehensive setup guide in itself. However, please note that it is _not_ necessary to copy the `.example` configuration files - in fact, the build script overwrites any values set in `security.properties` and `jdbc.properties`, anyway. 
+  *Note*: this is a gentle reminder to follow the main [README](https://github.com/opendatakit/aggregate), not a comprehensive setup guide in itself. 
   
-  The current recommended way to configure ODK Aggregate database settings is through [environmental variables](#configuration-parameters).
-
+  However, please note that if you are using [environmental variables](#Environmental-Variables) to configure Aggregate, it is _not_ necessary to copy the `.example` configuration files - in fact, the build script overwrites any values set in `security.properties` and `jdbc.properties`, anyway. If you would like to use these files instead of environmental variables to configure Aggregate, see the ["config files" section below](#config-files).  
+  
 ## Quick start
 
 This Aggregate Docker image works by using an external running PostgreSQL 9.6 database. The following quick start steps assume you have access to a PostgreSQL server and it's the first time you will be running Aggregate. 
@@ -107,9 +107,9 @@ docker run -d -p 8080:8080 -it \
 --mount type=bind,source="$(pwd)"/src/main/resources/odk-settings.xml,target=/etc/config/odk-settings.xml,readonly \
 --mount type=bind,source="$(pwd)"/src/main/resources/jdbc.properties,target=/etc/config/jdbc.properties,readonly \
 --mount type=bind,source="$(pwd)"/src/main/resources/security.properties,target=/etc/config/security.properties,readonly \
---name=aggregate aggregate:latest
+--name=aggregate aggregate:v2.0.1-10-g9c6afd90-dirty
 ```
 
-Of course, you can place these files anywhere on your server that you wish, as long as you update the "source" path above. You can also use this technique along with any Docker orchestration tool that supports mounting configuration values into files on the filesystem, [such as Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#populate-a-volume-with-data-stored-in-a-configmap). Just make sure the files are always mounted into `/etc/config`, as the `docker-entrypoint.sh` script makes symlinks from there into proper directory for Aggregate. You can also pass a custom Tomcat `server.xml`, though you shouldn't need to do this. 
+Of course, you can place these files anywhere on your server that you wish, as long as you update the "source" path above. You can also use this technique along with any Docker orchestration tool that supports mounting configuration values into files on the filesystem, [such as Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#populate-a-volume-with-data-stored-in-a-configmap). Just make sure the files are always mounted into `/etc/config`, as the `docker-entrypoint.sh` script makes symlinks from there into proper directory for Aggregate. You can also pass a custom Tomcat `server.xml`, though you shouldn't need to do this. Finally, you can also mount a Docker volume (not a bind )
 
-Finally, you can also continue to use the environmental variables technique above to override any values set in the files.
+You can also continue to use the environmental variables technique above to override any values set in the files.

--- a/docs/build-and-run-a-docker-image.md
+++ b/docs/build-and-run-a-docker-image.md
@@ -98,7 +98,7 @@ If you are using PostgreSQL (recommended), you can set the following environment
 
 ## Config Files
 
-For complete control of all of Aggregate's configuration values, you can also pass a copy of the `security.properties` and `jdbc.properties` files to Docker via a bind mount into the `/etc/config` directory in the Docker image. 
+For complete control of all of Aggregate's configuration values, you can also pass a copy of the `security.properties` and `jdbc.properties` files to Docker [via a bind mount](https://docs.docker.com/storage/bind-mounts/) into the `/etc/config` directory in the Docker image. 
 
 Follow the directions in the main `README` regarding copying the `/src/main/resources/jdbc.properties.example`, `odk-settings.xml.example` and `security.properties` files, and pass them to Docker kind of like so:
 
@@ -110,6 +110,6 @@ docker run -d -p 8080:8080 -it \
 --name=aggregate aggregate:latest
 ```
 
-Of course, you can place these files anywhere on your server that you wish, as long as you update the "source" directory above. You can also use this technique along with any Docker orchestration tool that supports mounting configuration values into files on the filesystem, [such as Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#populate-a-volume-with-data-stored-in-a-configmap). Just make sure the files are always mounted into `/etc/config`, as the `docker-entrypoint.sh` script makes symlinks from those directories into proper directory for Aggregate. You can also pass a custom Tomcat `server.xml`, though you shouldn't need to do this. 
+Of course, you can place these files anywhere on your server that you wish, as long as you update the "source" path above. You can also use this technique along with any Docker orchestration tool that supports mounting configuration values into files on the filesystem, [such as Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#populate-a-volume-with-data-stored-in-a-configmap). Just make sure the files are always mounted into `/etc/config`, as the `docker-entrypoint.sh` script makes symlinks from there into proper directory for Aggregate. You can also pass a custom Tomcat `server.xml`, though you shouldn't need to do this. 
 
-You can also continue to use the environmental variables technique above to override any values set in the files.
+Finally, you can also continue to use the environmental variables technique above to override any values set in the files.


### PR DESCRIPTION
*I’m working on deploying an Aggregate 2.0 instance to Kubernetes in the cleanest possible way, and documenting my progress in [these lab notes](https://brettneese.xyz/tagged/migrating-odk-to-k8s). The latest [post](https://brettneese.xyz/lab-notes-migrating-odk-aggregate-from-fargate-to-azure-kubernetes-services-part-2) describes the motivation behind this change in even more detail.*

This PR allows optionally passing files via Docker volumes into a `/etc/config` directory in the Docker image, which gets symlinked via changes to `docker-entrypoint.sh` to the proper place in Aggregate's config directory. This allows complete control over the files (for instance, to use a different DB engine than pgsql.) Currently this covers:

- `${AGGREGATE_CONF_DIR}/odk-settings.xml`
- `${AGGREGATE_CONF_DIR}/security.properties`
- `${AGGREGATE_CONF_DIR}/jdbc.properties`
-  `/usr/local/tomcat/conf/server.xml`

You can supply any combination of these files, the script will only make symlinks if they exist in the `/etc/config` directory volume.

This will mostly be useful for Kubernetes, as you can mount the values in k8s ConfigMaps as files in k8s Pods. But you can also pass the files from a local filesystem using bind mounts using `docker run` command like so:

```shell
docker run -d -p 8080:8080 -it \
--mount type=bind,source="$(pwd)"/src/main/resources/odk-settings.xml,target=/etc/config/odk-settings.xml,readonly \
--mount type=bind,source="$(pwd)"/src/main/resources/jdbc.properties,target=/etc/config/jdbc.properties,readonly \
--mount type=bind,source="$(pwd)"/src/main/resources/security.properties,target=/etc/config/security.properties,readonly \
--name=aggregate aggregate:v2.0.1-10-g9c6afd90-dirty
```

You can still pass environmental variables to override any values set in those passed files, though I'm not sure why you would considering they are only read at startup.

#### What has been done to verify that this works as intended?

I have run the above command and inspected the output. *I have not yet tried to spin up an ODK aggregate instance full-stack using k8s yet*; I will update this PR when I can confirm that works and then we can merge it (assuming there are no objections or suggested improvements - I'm totally open to input here.)

#### Why is this the best possible solution? Were any other approaches considered?

This provides a more flexible solution in addition to the current env-var based solution, allowing complete control over any values in these files. I considered continuing to expand on the env-var based solution already outlined (for instance, making more replacement rules for using MySQL instead of pgsql) but that seemed rather fragile and it creates an even large disconnect between how one usually configures Aggregate using files and how one configures Aggregate in Docker using environmental variables (which ultimately get slipped into the files anyway.)  

This makes the setup process super confusing, as it's not clear which values in the files documented in `aggregate-config.md` and `database-configurations.md` one can actually control via env vars in Docker, and frustrating if the proper env var mapping in the `docker-entrypoint.sh` script to change what you want to change hasn't been built yet.

This is much cleaner, particularly when using a Docker orchestration system that allows the injection of values into files in the running container, such as with k8s ConfigMaps. You can just include the entire contents of, for instance, `securities.properties` in your ConfigMap property.

#### Are there any risks to merging this code? If so, what are they?

Because I preserve the existing env var replacement code, I don't imagine there are, other than a bit of added docs complexity, which I tried to make as clear as possible.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

This PR already includes docs updates here, but when we stabilize the Docker config a bit maybe we should add a "Docker" section to the main docs.