### PR TITLE
Update AppEngine uploader app jar

### DIFF
--- a/installer/gae.zip
+++ b/installer/gae.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72e8c9e9d6f40ceceb9fed7a11167cd144ee0be3cd9aaf2949dde67f2469145b
-size 783930
+oid sha256:04711e9385d872090acd11c2db6c762f804fd77125f3410fa2544b138c930b51
+size 781025


### PR DESCRIPTION
This PR updates the AppEngine Uploaded app JAR that the installer uses to deploy Aggregate to AppEngine.

The new uploader includes https://github.com/opendatakit/aggregate-components/pull/5 to avoid problems due to the deprecation of the AppEngine Backends API by Google.