### PR TITLE
Issue 452 The installer is not configuring the hostname correctly

### DIFF
--- a/installer/project/components/params.xml
+++ b/installer/project/components/params.xml
@@ -21,17 +21,6 @@
       <cliOptionText>Output a .options file that contains the configuration from running the installer.</cliOptionText>
     </booleanParameter>
     <stringParameter>
-      <name>hostname</name>
-      <description>Hidden value used to hold resolved fully-qualfied hostname.</description>
-      <explanation></explanation>
-      <value></value>
-      <default></default>
-      <allowEmptyValue>1</allowEmptyValue>
-      <ask>0</ask>
-      <insertBefore>${parent_installdir}</insertBefore>
-      <width>40</width>
-    </stringParameter>
-    <stringParameter>
       <name>http_port</name>
       <description>Hidden value used to hold resolved http_port</description>
       <explanation></explanation>
@@ -301,14 +290,38 @@ Follow the ODK Aggregate Tomcat Install instructions (link below) to make your c
           </ruleList>
         </stringParameter>
         <stringParameter>
-          <name>raw_hostname</name>
+          <name>hostname</name>
           <description>Internet-visible IP address or DNS name:</description>
           <explanation></explanation>
           <value></value>
-          <default>localhost</default>
-          <allowEmptyValue>0</allowEmptyValue>
+          <default></default>
+          <allowEmptyValue>1</allowEmptyValue>
           <width>50</width>
         </stringParameter>
+        <labelParameter>
+          <name>hostname_label_optional</name>
+          <explanation>ODK Aggregate will try to resolve an IP address or DNS name for you if you leave this field empty.</explanation>
+          <ruleList>
+            <compareText>
+              <logic>equals</logic>
+              <text>${tomcat_authentication_should_configure}</text>
+              <value>0</value>
+            </compareText>
+          </ruleList>
+        </labelParameter>
+        <labelParameter>
+          <name>hostname_label_warning</name>
+          <explanation><![CDATA[Make sure you provide an IP address or DNS name matching your SSL certificate.
+
+ODK Aggregate will try to resolve an IP address or DNS name for you if you leave this field empty, but this can be unreliable in SSL configurations.]]></explanation>
+          <ruleList>
+            <compareText>
+              <logic>equals</logic>
+              <text>${tomcat_authentication_should_configure}</text>
+              <value>1</value>
+            </compareText>
+          </ruleList>
+        </labelParameter>
       </parameterList>
       <validationActionList>
         <throwError text="The HTTP/1.1 Connector Port is invalid">


### PR DESCRIPTION
Closes #452

Ensure that the installer sets the hostname in output conf files
- Previously, we had a post-installation action that would copy the value of raw_hostname to hostname and perform transformations conditionally if the user was using GAE
- When we removed support for GAE, we broke this by removing all the post-installation actions related to the hostname variable
- In this commit, raw_hostname becomes hostname, fixing the issue
- This commit also adds a couple of hints to help the user fill in a value.
- Users are reminded that the hostname must match their SSL certificate.

Screenshot of the `Apache Tomcat Port Configuration` screen when `no SSL` is selected:
![issue 451 screenshot 2](https://user-images.githubusercontent.com/205913/55940734-00596900-5c41-11e9-8e13-4ca7884a1328.png)

Screenshot of the `Apache Tomcat Port Configuration` screen when `SSL` is selected:
![issue 452 screenshot 1](https://user-images.githubusercontent.com/205913/55940736-018a9600-5c41-11e9-83df-1fa70e0d0ca8.png)

#### What has been done to verify that this works as intended?
Build the installer, run it and verify that the output `security.properties` is correctly configured with whatever value is set in the `Internet-visible IP address or DNS name` field

#### Why is this the best possible solution? Were any other approaches considered?
This fixes a bug introduced when removing GAE support from the current master branch

#### Are there any risks to merging this code? If so, what are they?
None.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.