### PR TITLE
Issue 459 avoid page load blocks

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
+++ b/src/main/java/org/opendatakit/aggregate/client/LayoutUtils.java
@@ -3,28 +3,14 @@ package org.opendatakit.aggregate.client;
 import static org.opendatakit.aggregate.buildconfig.BuildConfig.VERSION;
 
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.UIObject;
 
 public class LayoutUtils {
-  private static String latestVersion;
-
-  static native String getLatestVersion() /*-{
-    var req = new XMLHttpRequest();
-    req.open('GET', 'https://api.github.com/repos/opendatakit/aggregate/releases/latest', false);
-    req.send(null);
-    if (req.readyState === 4 && req.status === 200)
-      return JSON.parse(req.responseText).tag_name;
-  }-*/;
-
   static HTML buildVersionNote(UIObject parent) {
-    if (latestVersion == null)
-      latestVersion = getLatestVersion();
     String shortVersion = VERSION.contains("-") ? VERSION.substring(0, VERSION.indexOf("-")) : VERSION;
-    String versionNote = shortVersion.equals(latestVersion)
-        ? "You're up to date!"
-        : "<a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">Update available</a>";
-    HTML html = new HTML("<small>" + shortVersion + " - " + versionNote + "</small>");
+    HTML html = new HTML("<small>" + shortVersion + " - Checking versions...</small>");
     Style style = html.getElement().getStyle();
     style.setProperty("position", "fixed");
     style.setProperty("bottom", "0");
@@ -34,6 +20,18 @@ public class LayoutUtils {
 
     Style parentStyle = parent.getElement().getStyle();
     parentStyle.setProperty("paddingBottom", "40px");
+
+    SecureGWT.getPreferenceService().getVersioNote(new AsyncCallback<String>() {
+      @Override
+      public void onFailure(Throwable caught) {
+        html.setHTML("<small>" + shortVersion + " - Version check failed</small>");
+      }
+
+      @Override
+      public void onSuccess(String versionNote) {
+        html.setHTML("<small>" + versionNote + "</small>");
+      }
+    });
 
     return html;
   }

--- a/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
+++ b/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceService.java
@@ -33,4 +33,6 @@ public interface PreferenceService extends RemoteService {
 
   @XsrfProtect
   void setSkipMalformedSubmissions(Boolean skipMalformedSubmissions) throws RequestFailureException;
+
+  String getVersioNote();
 }

--- a/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceServiceAsync.java
+++ b/src/main/java/org/opendatakit/aggregate/client/preferences/PreferenceServiceAsync.java
@@ -24,4 +24,6 @@ public interface PreferenceServiceAsync {
 
   void setSkipMalformedSubmissions(Boolean skipMalformedSubmissions, AsyncCallback<Void> callback);
 
+  void getVersioNote(AsyncCallback<String> callback);
+
 }

--- a/src/main/java/org/opendatakit/aggregate/server/PreferenceServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/server/PreferenceServiceImpl.java
@@ -16,7 +16,19 @@
 
 package org.opendatakit.aggregate.server;
 
+import static org.opendatakit.aggregate.buildconfig.BuildConfig.VERSION;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.opendatakit.aggregate.ContextFactory;
 import org.opendatakit.aggregate.client.exception.RequestFailureException;
@@ -33,9 +45,27 @@ public class PreferenceServiceImpl extends RemoteServiceServlet implements
 
   private static final Logger log = LoggerFactory.getLogger(PreferenceServiceImpl.class);
   /**
+   * Holds the latest available version as reported by GitHub
+   */
+  private static String LATEST_AVAILABLE_VERSION = null;
+  /**
+   * Defines the period to refresh the latest available version value
+   */
+  private static final Duration PERIOD_OF_REFRESH_LATEST_AVAILABLE_VERSION = Duration.ofDays(1);
+  /**
+   * Holds the date of the last refresh of the latest available version.
+   * <p>
+   * On launch, holds a remote date in the past to ensure that we will
+   * refresh the value even if the first request comes before the set
+   * period has passed since the server's launch.
+   */
+  private static LocalDate LAST_REFRESH_OF_LATEST_AVAILABLE_VERSION = LocalDate.of(2000, 1, 1);
+
+  /**
    * Serialization Identifier
    */
   private static final long serialVersionUID = -489283284844600170L;
+  public static final ObjectMapper JSON = new ObjectMapper();
 
   @Override
   public PreferenceSummary getPreferences() throws RequestFailureException {
@@ -72,5 +102,45 @@ public class PreferenceServiceImpl extends RemoteServiceServlet implements
       throw new RequestFailureException(ErrorConsts.QUOTA_EXCEEDED);
     }
 
+  }
+
+  @Override
+  public String getVersioNote() {
+    String shortVersion = VERSION.contains("-") ? VERSION.substring(0, VERSION.indexOf("-")) : VERSION;
+    String latestAvailableVersion = getLatestAvailableVersion();
+    return latestAvailableVersion == null
+        ? shortVersion + " - Version check failed"
+        : shortVersion.equals(latestAvailableVersion)
+        ? shortVersion + " - You're up to date!"
+        : shortVersion + " - <a href=\"https://github.com/opendatakit/aggregate/releases/latest\" target=\"_blank\">Update available</a>";
+  }
+
+  synchronized private static String getLatestAvailableVersion() {
+    if (latestAvailableVersionRefreshRequired()) {
+      try {
+        log.warn("Getting latest available version");
+        URL url = new URL("https://api.github.com/repos/opendatakit/aggregate/releases/latest");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("GET");
+        if (con.getResponseCode() == 200)
+          try (InputStream in = con.getInputStream()) {
+            LATEST_AVAILABLE_VERSION = Optional.ofNullable(JSON.readTree(in))
+                .map(node -> node.get("tag_name"))
+                .map(JsonNode::asText)
+                .orElse(null);
+          }
+        else
+          log.error("Can't get latest available version - GitHub responded with HTTP " + con.getResponseCode() + " " + con.getResponseMessage());
+        LAST_REFRESH_OF_LATEST_AVAILABLE_VERSION = LocalDate.now();
+      } catch (IOException e) {
+        log.error("Can't get latest available version", e);
+      }
+    }
+    return LATEST_AVAILABLE_VERSION;
+  }
+
+  private static boolean latestAvailableVersionRefreshRequired() {
+    return Duration.between(LAST_REFRESH_OF_LATEST_AVAILABLE_VERSION.atStartOfDay(), LocalDateTime.now()).abs()
+        .compareTo(PERIOD_OF_REFRESH_LATEST_AVAILABLE_VERSION) > 0;
   }
 }

--- a/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/AggregateHtmlServlet.java
@@ -65,7 +65,7 @@ public class AggregateHtmlServlet extends ServletUtilBase {
       + "   <script type=\"text/javascript\" language=\"javascript\" src=\"javascript/main.js\"></script>"
       + "    <script type=\"text/javascript\" language=\"javascript\" src=\"aggregateui/aggregateui.nocache.js\"></script>"
       + "    <script type=\"text/javascript\" language=\"javascript\" src=\"https://maps.googleapis.com/maps/api/js?";
-  public static final String PAGE_CONTENTS_SECOND = "sensor=false\"></script>"
+  public static final String PAGE_CONTENTS_SECOND = "sensor=false\" async></script>"
       + "    <link type=\"text/css\" rel=\"stylesheet\" href=\"AggregateUI.css\">"
       + "    <link type=\"text/css\" rel=\"stylesheet\" href=\"stylesheets/button.css\">"
       + "    <link type=\"text/css\" rel=\"stylesheet\" href=\"stylesheets/table.css\">"


### PR DESCRIPTION
Closes #459

#### What has been done to verify that this works as intended?

I've used Chrome's inspector for all these tests with the "Disable cache" from the network tab enabled.

**Version note blocking issues**
- Start Aggregate in `localhost` and verify that I get the "you're up to date" note. 
- Restart Aggregate, disable the network connection and verify that I get the "version check failed" note.

**Google maps JS blocking issues**
- Start Aggregate and verify with the inspector that the script gets eventually loaded.
- Restart Aggregate, disable the network connection and verify that I get an error but the page still loads.

#### Why is this the best possible solution? Were any other approaches considered?
First I tried to modify the client's JSNI implementation in `LayoutUtils.java` to handle errors related to the requests to GitHub's API, but I got to very complicated half-solutions due to conflicts between the blocking nature of GWT Java UI building and the asynchronous XMLHttpRequest.

Then I decided to switch to an all-Java server-side solution. At the expense of having a new GWT service, now we completely avoid client-side JSNI code and the asynchronous interaction is entirely made through GWT RPC calls, which is results in much simpler client code.

Thanks to moving this code to the server, we're also able to throttle-control calls to GitHub's API (and avoid nasty temporary bans due to spamming it with requests). Now, instead the clients (potentially many) doing calls to GH, it's the server who does 1 request per 24 hours max.

#### Are there any risks to merging this code? If so, what are they?
None.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.