### PR TITLE
Issue #455 Restore the Location header in HEAD pre-flight responses

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/servlet/FormUploadServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/FormUploadServlet.java
@@ -189,6 +189,8 @@ public class FormUploadServlet extends ServletUtilBase {
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) {
     addOpenRosaHeaders(resp);
+    // TODO Remove this header when no client relies on it to identify legacy Aggregate servers (v0.9 or older)
+    resp.setHeader("Location", String.format("%s/%s", ContextFactory.getCallingContext(this, req).getServerURL(), ADDR));
     resp.setStatus(204);
   }
 

--- a/src/main/java/org/opendatakit/aggregate/servlet/ResetUsersAndPermissionsServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/ResetUsersAndPermissionsServlet.java
@@ -179,6 +179,8 @@ public class ResetUsersAndPermissionsServlet extends ServletUtilBase {
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) {
     addOpenRosaHeaders(resp);
+    // TODO Remove this header when no client relies on it to identify legacy Aggregate servers (v0.9 or older)
+    resp.setHeader("Location", String.format("%s/%s", ContextFactory.getCallingContext(this, req).getServerURL(), ADDR));
     resp.setStatus(204);
   }
 

--- a/src/main/java/org/opendatakit/aggregate/servlet/SubmissionServlet.java
+++ b/src/main/java/org/opendatakit/aggregate/servlet/SubmissionServlet.java
@@ -190,6 +190,8 @@ public class SubmissionServlet extends ServletUtilBase {
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) {
     addOpenRosaHeaders(resp);
+    // TODO Remove this header when no client relies on it to identify legacy Aggregate servers (v0.9 or older)
+    resp.setHeader("Location", String.format("%s/%s", ContextFactory.getCallingContext(this, req).getServerURL(), ADDR));
     resp.setStatus(204);
   }
 


### PR DESCRIPTION
Closes #455

#### What has been done to verify that this works as intended?
Run Aggregate and use curl to verify that the `Location` header is in the response of the HEAD. I verified the two that can be accessed without auth and expect that the third will work because it has been changed the same way.

```
$ curl -XHEAD -I http://localhost:8080/formUpload
HTTP/1.1 204 No Content
Date: mié, 24 abr 2019 08:26:05 GMT
X-OpenRosa-Version: 1.0
X-OpenRosa-Accept-Content-Length: 10485760
Location: http://localhost:8080/formUpload
Server: Jetty(9.2.22.v20170606)


$ curl -XHEAD -I http://localhost:8080/submission
HTTP/1.1 204 No Content
Date: mié, 24 abr 2019 08:26:11 GMT
X-OpenRosa-Version: 1.0
X-OpenRosa-Accept-Content-Length: 10485760
Location: http://localhost:8080/submission
Server: Jetty(9.2.22.v20170606)
```

#### Why is this the best possible solution? Were any other approaches considered?
This is the old code that's running in 1.7 slightly refactored into just one line. 

#### Are there any risks to merging this code? If so, what are they?
It's a pretty straightforward change that doesn't affect any other behavior in Aggregate. I wouldn't expect any risk to merging this PR.

#### Do we need any specific form for testing your changes? If so, please attach one
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.