### PR TITLE
Improve the installerBuild task to produce the installers

### DIFF
--- a/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/Util.groovy
+++ b/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/Util.groovy
@@ -46,4 +46,22 @@ class Util {
       return obj.getProperty(key)
     return defaultValue
   }
+
+  static void run(command) {
+    def proc = command.toString().execute()
+    def b = new StringBuffer()
+    proc.consumeProcessErrorStream(b)
+
+    println proc.text
+    println b.toString()
+  }
+
+  static void run(command, wd) {
+    def proc = command.toString().execute(null, new File(wd.toString()))
+    def b = new StringBuffer()
+    proc.consumeProcessErrorStream(b)
+
+    println proc.text
+    println b.toString()
+  }
 }

--- a/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/Util.groovy
+++ b/buildSrc/src/main/groovy/org/opendatakit/aggregate/gradle/Util.groovy
@@ -47,8 +47,8 @@ class Util {
     return defaultValue
   }
 
-  static void run(command) {
-    def proc = command.toString().execute()
+  static void run(String... command) {
+    def proc = command.execute()
     def b = new StringBuffer()
     proc.consumeProcessErrorStream(b)
 
@@ -56,8 +56,8 @@ class Util {
     println b.toString()
   }
 
-  static void run(command, wd) {
-    def proc = command.toString().execute(null, new File(wd.toString()))
+  static void runInWorkingDir(wd, String... command) {
+    def proc = command.execute(null, new File(wd.toString()))
     def b = new StringBuffer()
     proc.consumeProcessErrorStream(b)
 

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -2,3 +2,6 @@
 #packerZip=https://releases.hashicorp.com/packer/1.3.4/packer_1.3.4_linux_amd64.zip
 #packerZip=https://releases.hashicorp.com/packer/1.3.4/packer_1.3.4_windows_amd64.zip
 #packerZip=https://releases.hashicorp.com/packer/1.3.4/packer_1.3.4_darwin_amd64.zip
+
+#Uncomment and set the path to the installBuilder installation directory
+#installBuilderHome=/opt/installbuilder-18.10.0

--- a/installer.gradle
+++ b/installer.gradle
@@ -1,5 +1,4 @@
-import static org.opendatakit.aggregate.gradle.Util.run
-import static org.opendatakit.aggregate.gradle.Util.setXmlValue
+import static org.opendatakit.aggregate.gradle.Util.*
 
 task installerClean() {
   delete 'build/installer'
@@ -28,18 +27,18 @@ task installerBuild(dependsOn: [installerClean], type: Copy) {
     file("${buildDir}/installer/files/${archivesBaseName}-${version}.war").renameTo(file("build/installer/files/ODKAggregate.war"))
 
     if (installBuilderHome != null) {
-      run("mkdir ${buildDir}/installers")
+      run("mkdir", "${buildDir}/installers")
       setXmlValue("${buildDir}/installer/buildWar.xml", "outputDirectory", "${buildDir}/installers")
 
       [["linux-x64", "Linux-x64.run"],
        ["linux", "Linux.run"],
        ["windows", "Windows.exe"],
-       ["osx", "macOs.app"]
+       ["osx", "macOS.app"]
       ].forEach({ pair ->
         setXmlValue("${buildDir}/installer/buildWar.xml", "installerFilename", "ODK-Aggregate-${version}-${pair[1]}")
-        run("${installBuilderHome}/bin/builder build ${buildDir}/installer/buildWar.xml ${pair[0]}")
-        run("zip ODK-Aggregate-${version}-${pair[1]}.zip ODK-Aggregate-${version}-${pair[1]}", "${buildDir}/installers")
-        run("rm -r ODK-Aggregate-${version}-${pair[1]}", "${buildDir}/installers")
+        run("${installBuilderHome}/bin/builder", "build", "${buildDir}/installer/buildWar.xml", "${pair[0]}")
+        runInWorkingDir("${buildDir}/installers", "zip", "-r", "ODK-Aggregate-${version}-${pair[1]}.zip", "ODK-Aggregate-${version}-${pair[1]}")
+        runInWorkingDir("${buildDir}/installers", "rm", "-r", "ODK-Aggregate-${version}-${pair[1]}")
       })
     }
   }

--- a/installer.gradle
+++ b/installer.gradle
@@ -1,7 +1,9 @@
+import static org.opendatakit.aggregate.gradle.Util.run
 import static org.opendatakit.aggregate.gradle.Util.setXmlValue
 
 task installerClean() {
   delete 'build/installer'
+  delete 'build/installers'
 }
 
 task installerBuild(dependsOn: [installerClean], type: Copy) {
@@ -24,5 +26,21 @@ task installerBuild(dependsOn: [installerClean], type: Copy) {
   doLast {
     setXmlValue("${buildDir}/installer/buildWar.xml", "version", version)
     file("${buildDir}/installer/files/${archivesBaseName}-${version}.war").renameTo(file("build/installer/files/ODKAggregate.war"))
+
+    if (installBuilderHome != null) {
+      run("mkdir ${buildDir}/installers")
+      setXmlValue("${buildDir}/installer/buildWar.xml", "outputDirectory", "${buildDir}/installers")
+
+      [["linux-x64", "Linux-x64.run"],
+       ["linux", "Linux.run"],
+       ["windows", "Windows.exe"],
+       ["osx", "macOs.app"]
+      ].forEach({ pair ->
+        setXmlValue("${buildDir}/installer/buildWar.xml", "installerFilename", "ODK-Aggregate-${version}-${pair[1]}")
+        run("${installBuilderHome}/bin/builder build ${buildDir}/installer/buildWar.xml ${pair[0]}")
+        run("zip ODK-Aggregate-${version}-${pair[1]}.zip ODK-Aggregate-${version}-${pair[1]}", "${buildDir}/installers")
+        run("rm -r ODK-Aggregate-${version}-${pair[1]}", "${buildDir}/installers")
+      })
+    }
   }
 }

--- a/installer/project/buildWar.xml
+++ b/installer/project/buildWar.xml
@@ -34,5 +34,7 @@
   </customLanguageFileList>
   <finalPageActionList>
   </finalPageActionList>
+  <installerFilename>${product_shortname}-${product_version}-${platform_name}-installer.${platform_exec_suffix}</installerFilename>
+  <outputDirectory>/tmp</outputDirectory>
 </project>
 


### PR DESCRIPTION
Now the Gradle task will automate the generation of all the installer if the installBuilderHome variable is set.

- The installers are generated following the filename templates we require in our releases.
- The task will only work in Linux and macOS hosts.
- The installers are built and zipped by the task, and they can be found at `build/installers`

The way to run the task hasn't changed: 
`./gradlew clean build installerBuild -xtest -PwarMode=installer`