### PR TITLE
allow any 2XX status code from an external JSON server

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/externalservice/JsonServer.java
+++ b/src/main/java/org/opendatakit/aggregate/externalservice/JsonServer.java
@@ -134,7 +134,7 @@ public class JsonServer extends AbstractExternalService implements ExternalServi
       }
       if (statusCode == HttpServletResponse.SC_UNAUTHORIZED) {
         throw new ODKExternalServiceCredentialsException(reason + " (" + statusCode + ")");
-      } else if (statusCode != HttpServletResponse.SC_OK) {
+      } else if (statusCode < HttpServletResponse.SC_OK || statusCode >= 300) {
         throw new ODKExternalServiceException(reason + " (" + statusCode + ")");
       }
     } catch (ODKExternalServiceException e) {


### PR DESCRIPTION
When a server responds with another 2XX code, such as 201 the server treats this as an error. This accepts any 2XX response.

I used the number 300 instead of SC_MULTIPLE_CHOICES as that constant's name doesn't signify the start of the non success range.

#### What has been done to verify that this works as intended?
We'll be deploying this shortly.

#### Why is this the best possible solution? Were any other approaches considered?
Any 2XX code is a success code.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one
No

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.